### PR TITLE
Lattice view grid style

### DIFF
--- a/ls-ui-react-app/src/components/LatticeView.tsx
+++ b/ls-ui-react-app/src/components/LatticeView.tsx
@@ -118,7 +118,9 @@ const SliceViewer = ({slice} : SliceViewerProps) =>
         {slice.map((row, row_idx) =>
             <div className="lattice-row" key={row_idx}>
                 {row.map((cell, col_idx) =>
-                    <CellViewer cell={cell} row_idx={row_idx} col_idx={row_idx} key={col_idx}/>
+                    <div className="lattice-cell" key={col_idx}>
+                        <CellViewer cell={cell} row_idx={row_idx} col_idx={row_idx} key={col_idx}/>
+                    </div>
                 )}
             </div>
         )}

--- a/ls-ui-react-app/src/components/LatticeView.tsx
+++ b/ls-ui-react-app/src/components/LatticeView.tsx
@@ -49,8 +49,8 @@ const styles_map_activity_color: StylesMapActivityColorType = {
 
 const cellFontSize = (cell : VisualArrayCell) =>
     cell.text.length > 20
-        ? "7"
-        : cell.text.length > 7 ? "9" : "15"
+        ? "14"
+        : cell.text.length > 7 ? "18" : "30"
 
 type CellViewerProps = {
     cell: VisualArrayCell

--- a/ls-ui-react-app/src/components/LatticeView.tsx
+++ b/ls-ui-react-app/src/components/LatticeView.tsx
@@ -62,8 +62,8 @@ const CellViewer = ({cell, row_idx, col_idx}: CellViewerProps) => {
     return <div
             className="lattice-cell-inside"
             css={css`
-                height: 50pt;
-                width: 50pt;
+                height:100%;
+                width:100%;
                 vertical-align: middle;
                 display: inline-block;
                 border-width: 4pt;
@@ -114,11 +114,11 @@ type SliceViewerProps = {
     slice: Slice
 }
 const SliceViewer = ({slice} : SliceViewerProps) =>
-    <div className="slice">
+    <div className="slice grid">
         {slice.map((row, row_idx) =>
-            <div className="lattice-row" key={row_idx}>
+            <div className="lattice-row row flex-nowrap" key={row_idx}>
                 {row.map((cell, col_idx) =>
-                    <div className="lattice-cell" key={col_idx}>
+                    <div className="lattice-cell ratio ratio-1x1 col" key={col_idx}>
                         <CellViewer cell={cell} row_idx={row_idx} col_idx={row_idx} key={col_idx}/>
                     </div>
                 )}
@@ -174,7 +174,7 @@ const LatticeView = ({compilationResult} : LatticeViewProps) => {
             <a href="/" className="btn btn-info p-2"> New Circuit </a>
         </div>
         
-        <div id="draggable-container" className="mt-5">
+        <div id="draggable-container" className="mt-1">
             <SliceViewer slice={slices[selectedSliceNumber]} />
         </div>
     </div>

--- a/ls-ui-react-app/src/pages/LatticeViewPage.css
+++ b/ls-ui-react-app/src/pages/LatticeViewPage.css
@@ -53,7 +53,3 @@
   padding-left: 0px;
   padding-right: 0px;
 }
-
-/* @media (mix-width:700px) {
-
-} */

--- a/ls-ui-react-app/src/pages/LatticeViewPage.css
+++ b/ls-ui-react-app/src/pages/LatticeViewPage.css
@@ -46,7 +46,7 @@
   width: 12vw;
   /* display: inline-block; */
   position: relative;
-  font-size:9px;
+  font-size:18px;
 }
 
 .qubit-state{

--- a/ls-ui-react-app/src/pages/LatticeViewPage.css
+++ b/ls-ui-react-app/src/pages/LatticeViewPage.css
@@ -12,7 +12,6 @@
 
 #lattice-view-output {
   /*Hacky way to make sure footer stays at the bottom when there isn't much page content*/
-  /* min-height:80vh; */
   margin-bottom: 20px;
 }
 

--- a/ls-ui-react-app/src/pages/LatticeViewPage.css
+++ b/ls-ui-react-app/src/pages/LatticeViewPage.css
@@ -38,11 +38,9 @@
 
 .lattice-cell{
   border: 0.5px solid #a2abae;
-  /* height: fit-content; */
   min-width: 50px;
   max-width:130px;
   width: 12vw;
-  /* display: inline-block; */
   position: relative;
   font-size:18px;
 }

--- a/ls-ui-react-app/src/pages/LatticeViewPage.css
+++ b/ls-ui-react-app/src/pages/LatticeViewPage.css
@@ -42,7 +42,7 @@
   border: 0.5px solid #a2abae;
   /* height: fit-content; */
   min-width: 50px;
-  max-width:100px;
+  max-width:130px;
   width: 12vw;
   /* display: inline-block; */
   position: relative;

--- a/ls-ui-react-app/src/pages/LatticeViewPage.css
+++ b/ls-ui-react-app/src/pages/LatticeViewPage.css
@@ -11,7 +11,6 @@
 }
 
 #lattice-view-output {
-  /*Hacky way to make sure footer stays at the bottom when there isn't much page content*/
   margin-bottom: 20px;
 }
 

--- a/ls-ui-react-app/src/pages/LatticeViewPage.css
+++ b/ls-ui-react-app/src/pages/LatticeViewPage.css
@@ -1,13 +1,5 @@
 /* lattice view styles */
 
-/*html, body{
-  height: 100%;
-  padding: 0;
-  margin: 0;
-  white-space: nowrap;
-  overflow: hidden;
-}*/
-
 .lattice-card{
   border: 2px solid black;
   border-radius: 15px;
@@ -20,7 +12,8 @@
 
 #lattice-view-output {
   /*Hacky way to make sure footer stays at the bottom when there isn't much page content*/
-  min-height: 90vh;
+  /* min-height:80vh; */
+  margin-bottom: 20px;
 }
 
 #toolbar{
@@ -40,11 +33,18 @@
   z-index: 10;
 }
 
+.lattice-row {
+  width:100%;
+  margin: auto;
+}
+
 .lattice-cell{
   border: 0.5px solid #a2abae;
-  height: 50pt;
-  width: 50pt;
-  display: inline-block;
+  /* height: fit-content; */
+  min-width: 50px;
+  max-width:100px;
+  width: 12vw;
+  /* display: inline-block; */
   position: relative;
   font-size:9px;
 }
@@ -52,3 +52,12 @@
 .qubit-state{
   line-height: 1;
 }
+
+.col {
+  padding-left: 0px;
+  padding-right: 0px;
+}
+
+/* @media (mix-width:700px) {
+
+} */


### PR DESCRIPTION
Brought back the previous lattice view styles and made them responsive on devices with viewports 320px and up.

Dragging looks like it was implemented with JS and can come on another PR if you still want it. 

Let me know if you still want the scroll-zooming functionality. I suspect that a responsive layout is superior, though we can certainly add some +/- zoom buttons and even a rotate button to view on mobile.

closes #8 except for the drag/zoom features.