### PR TITLE
Update so changes in `.github/` will not trigger deployment to AWS 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]
     paths-ignore:
       - '**.md'
+      - '.github/**'
   pull_request:
     branches: [ main ]
     paths-ignore:


### PR DESCRIPTION
As title. 

Keeping things as they are for PRs - if I update anything in our CI workflow I want to see the changes take place on the PR anyway (and that Surge deployment only lives until the PR is closed).