### PR TITLE
Adding Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,11 +6,9 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "saturday"
+      interval: "daily"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "saturday"
+      interval: "daily"

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,16 @@
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "saturday"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,6 +80,8 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'latticesurgery-com' && github.event_name == 'pull_request'
     needs: [build]
+    permissions:
+      pull-requests: write 
     env:
       SURGE_DOMAIN: ${{ format('https://{0}-{1}-pr{2}-preview.surge.sh', github.repository_owner, 
         github.event.repository.name, github.event.pull_request.number) }}
@@ -114,7 +116,6 @@ jobs:
 
     - name: Share/Update deployment link
       uses: peter-evans/create-or-update-comment@v1
-      continue-on-error: true
       with:
         comment-id: ${{ steps.fc.outputs.comment-id }}
         issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -114,6 +114,7 @@ jobs:
 
     - name: Share/Update deployment link
       uses: peter-evans/create-or-update-comment@v1
+      continue-on-error: true
       with:
         comment-id: ${{ steps.fc.outputs.comment-id }}
         issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/preview-teardown.yml
+++ b/.github/workflows/preview-teardown.yml
@@ -33,7 +33,6 @@ jobs:
         body-includes: Preview is deployed to 
 
     - name: Teardown preview on Surge
-      if: ${{ steps.fc.outputs.comment-id != 0 }}
       continue-on-error: true
       run: surge teardown ${{ env.SURGE_DOMAIN }}
       env:


### PR DESCRIPTION
As title. With this we can automate the dependencies update process. Also update current Github Actions workflow to work with Dependabot. 

~~A current problem is that for Dependabot's PRs, there won't be any deployment link comment posted as the Github Token it has access to is read-only. I have updated the workflow so it won't fail the CI, and that the Surge deployment and teardown will still happen as normal (though you would have to go to actions log to grab the Surge preview deployment link).~~ This is fixed.