### PR TITLE
Remove bootstrap comps

### DIFF
--- a/src/components/SliceIndexBar.tsx
+++ b/src/components/SliceIndexBar.tsx
@@ -15,8 +15,8 @@ const SliceIndexBar = ({ count, selected }: SliceIndexBarProps): JSX.Element => 
                         const color = index == selected ? "#292cff" : "lightgrey"
                         return (
                             <Box
-                                h="30px"
-                                w="30px"
+                                h="35px"
+                                w="35px"
                                 rounded="lg"
                                 key={index}
                                 border="5px"

--- a/src/components/SliceIndexBar.tsx
+++ b/src/components/SliceIndexBar.tsx
@@ -8,30 +8,28 @@ const SliceIndexBar = ({ count, selected }: SliceIndexBarProps): JSX.Element => 
     const nElements = Array.from(Array(count).keys())
     // const [selectedIndex, setSelectedIndex] = React.useState(0)
     return (
-        <>
-            <Box border={"6px"} borderColor="black">
-                <Flex flexWrap={"wrap"} gap={1}>
-                    {nElements.map(function (element, index) {
-                        const color = index == selected ? "#292cff" : "lightgrey"
-                        return (
-                            <Box
-                                h="35px"
-                                w="35px"
-                                rounded="lg"
-                                key={index}
-                                border="5px"
-                                backgroundColor={color}
-                                textColor="white"
-                            >
-                                <Center>
-                                    <Text>{index == selected ? index : null}</Text>
-                                </Center>
-                            </Box>
-                        )
-                    })}
-                </Flex>
-            </Box>
-        </>
+        <Box border={"6px"} borderColor="black">
+            <Flex flexWrap={"wrap"} gap={1}>
+                {nElements.map(function (element, index) {
+                    const color = index == selected ? "#292cff" : "lightgrey"
+                    return (
+                        <Box
+                            h="35px"
+                            w="35px"
+                            rounded="lg"
+                            key={index}
+                            border="5px"
+                            backgroundColor={color}
+                            textColor="white"
+                        >
+                            <Center>
+                                <Text>{index == selected ? index : null}</Text>
+                            </Center>
+                        </Box>
+                    )
+                })}
+            </Flex>
+        </Box>
     )
 }
 

--- a/src/components/SliceIndexBar.tsx
+++ b/src/components/SliceIndexBar.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex,Center,Text } from "@chakra-ui/react"
+import { Box, Flex, Center, Text } from "@chakra-ui/react"
 
 type SliceIndexBarProps = {
     count: number
@@ -22,7 +22,11 @@ const SliceIndexBar = ({ count, selected }: SliceIndexBarProps): JSX.Element => 
                                 border="5px"
                                 backgroundColor={color}
                                 textColor="white"
-                            ><Center><Text>{index==selected? index:null}</Text></Center></Box>
+                            >
+                                <Center>
+                                    <Text>{index == selected ? index : null}</Text>
+                                </Center>
+                            </Box>
                         )
                     })}
                 </Flex>

--- a/src/components/SliceIndexBar.tsx
+++ b/src/components/SliceIndexBar.tsx
@@ -3,31 +3,38 @@ import { Box, Flex, Center, Text } from "@chakra-ui/react"
 type SliceIndexBarProps = {
     count: number
     selected: number
+    setSlice: (num: number) => void
 }
-const SliceIndexBar = ({ count, selected }: SliceIndexBarProps): JSX.Element => {
+const SliceIndexBar = ({ count, selected, setSlice }: SliceIndexBarProps): JSX.Element => {
     const nElements = Array.from(Array(count).keys())
-    // const [selectedIndex, setSelectedIndex] = React.useState(0)
+    const flex_gap = 0
+    // const [selectedSlice, setSelectedSlice] = React.useState<number>(initial)
+    const handleChange = (ind: number) => {
+        setSlice(ind)
+    }
     return (
-        <Box border={"6px"} borderColor="black">
-            <Flex flexWrap={"wrap"} gap={1}>
+        <Box borderWidth="3px" borderColor="black" maxW="400px" rounded="xl" p="1" boxShadow={"lg"}>
+            <Flex gap={flex_gap}>
                 {nElements.map(function (element, index) {
-                    const color = index == selected ? "#292cff" : "lightgrey"
+                    const color = index <= selected ? "#4299e1" : "lightgrey"
                     return (
                         <Box
-                            h="35px"
-                            w="35px"
-                            rounded="lg"
+                            h="40px"
+                            width={200 / count - count * flex_gap}
                             key={index}
-                            border="5px"
+                            borderWidth="0.75px"
+                            borderColor="white"
                             backgroundColor={color}
                             textColor="white"
-                        >
-                            <Center>
-                                <Text>{index == selected ? index : null}</Text>
-                            </Center>
-                        </Box>
+                            onClick={() => handleChange(index)}
+                        ></Box>
                     )
                 })}
+                <Box width="50px">
+                    <Center>
+                        <Text>{selected + 1}</Text>
+                    </Center>
+                </Box>
             </Flex>
         </Box>
     )

--- a/src/components/SliceIndexBar.tsx
+++ b/src/components/SliceIndexBar.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex } from "@chakra-ui/react"
+import { Box, Flex,Center,Text } from "@chakra-ui/react"
 
 type SliceIndexBarProps = {
     count: number
@@ -21,7 +21,8 @@ const SliceIndexBar = ({ count, selected }: SliceIndexBarProps): JSX.Element => 
                                 key={index}
                                 border="5px"
                                 backgroundColor={color}
-                            ></Box>
+                                textColor="white"
+                            ><Center><Text>{index==selected? index:null}</Text></Center></Box>
                         )
                     })}
                 </Flex>

--- a/src/components/SliceIndexBar.tsx
+++ b/src/components/SliceIndexBar.tsx
@@ -1,0 +1,44 @@
+import {
+    VStack,
+    Box,
+    Heading,
+    Center,
+    Switch,
+    FormLabel,
+    Flex,
+    Text,
+    Button,
+} from "@chakra-ui/react"
+import React from "react"
+
+type SliceIndexBarProps = {
+    count: number
+    selected: number
+}
+const SliceIndexBar = ({ count, selected }: SliceIndexBarProps): JSX.Element => {
+    const nElements = Array.from(Array(count).keys())
+    // const [selectedIndex, setSelectedIndex] = React.useState(0)
+    return (
+        <>
+            <Box border={"6px"} borderColor="black">
+                <Flex flexWrap={"wrap"} gap={1}>
+                    {nElements.map(function (element, index) {
+                        var color = index == selected ? "#292cff" : "lightgrey"
+                        return (
+                            <Box
+                                h="30px"
+                                w="30px"
+                                rounded="lg"
+                                key={index}
+                                border="5px"
+                                backgroundColor={color}
+                            ></Box>
+                        )
+                    })}
+                </Flex>
+            </Box>
+        </>
+    )
+}
+
+export default SliceIndexBar

--- a/src/components/SliceIndexBar.tsx
+++ b/src/components/SliceIndexBar.tsx
@@ -1,15 +1,4 @@
-import {
-    VStack,
-    Box,
-    Heading,
-    Center,
-    Switch,
-    FormLabel,
-    Flex,
-    Text,
-    Button,
-} from "@chakra-ui/react"
-import React from "react"
+import { Box, Flex } from "@chakra-ui/react"
 
 type SliceIndexBarProps = {
     count: number
@@ -23,7 +12,7 @@ const SliceIndexBar = ({ count, selected }: SliceIndexBarProps): JSX.Element => 
             <Box border={"6px"} borderColor="black">
                 <Flex flexWrap={"wrap"} gap={1}>
                     {nElements.map(function (element, index) {
-                        var color = index == selected ? "#292cff" : "lightgrey"
+                        const color = index == selected ? "#292cff" : "lightgrey"
                         return (
                             <Box
                                 h="30px"

--- a/src/components/sections/LatticeView.css
+++ b/src/components/sections/LatticeView.css
@@ -10,12 +10,6 @@
     text-align: center;
 }
 
-.vcenter {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-}
-
 #lattice-view-output {
     margin-bottom: 20px;
 }

--- a/src/components/sections/LatticeView.css
+++ b/src/components/sections/LatticeView.css
@@ -10,11 +10,6 @@
   text-align:center;
 }
 
-/* .vertical-center{
-  display: flex;
-  align-items: center;
-} */
-
 #lattice-view-output {
   margin-bottom: 20px;
 }

--- a/src/components/sections/LatticeView.css
+++ b/src/components/sections/LatticeView.css
@@ -1,64 +1,74 @@
 /* lattice view styles */
 
-.lattice-card{
-  border: 2px solid black;
-  border-radius: 15px;
-  width:200px;
-  background-color:#ffdbb3 !important;
+.lattice-card {
+    border: 2px solid black;
+    border-radius: 15px;
+    width: 200px;
+    background-color: #ffdbb3 !important;
 }
 .center {
-  text-align:center;
+    text-align: center;
+}
+
+.vcenter {
+    display: flex;
+    justify-content: center;
+    align-items: center;
 }
 
 #lattice-view-output {
-  margin-bottom: 20px;
+    margin-bottom: 20px;
 }
 
-#toolbar{
+#toolbar {
     /* Make it independent of zoom */
-  height: 10%;
-  line-height: 10vh;
-  font-size: 5vh;
-  /* Keep it above the lattice */
-  z-index: 100;
-  position: relative;
-  /* style */
-  background-color: lavender;
-  border-bottom: solid darkgrey 1.5vh;
+    height: 10%;
+    line-height: 10vh;
+    font-size: 5vh;
+    /* Keep it above the lattice */
+    z-index: 100;
+    position: relative;
+    /* style */
+    background-color: lavender;
+    border-bottom: solid darkgrey 1.5vh;
 }
-#draggable-container{
-  font-size: 0;
-  z-index: 10;
+#draggable-container {
+    font-size: 0;
+    z-index: 10;
 }
 
 .lattice-row {
-  width:100%;
-  margin: auto;
+    width: 100%;
+    margin: auto;
 }
 
-.lattice-cell{
-  border: 0.5px solid #a2abae;
-  min-width: 50px;
-  max-width:130px;
-  width: 12vw;
-  position: relative;
-  font-size:18px;
+.lattice-cell {
+    border: 0.5px solid #a2abae;
+    min-width: 50px;
+    max-width: 130px;
+    width: 12vw;
+    position: relative;
+    font-size: 18px;
 }
 
-.qubit-state{
-  line-height: 1;
+.qubit-state {
+    line-height: 1;
 }
 
 .col {
-  padding-left: 0px;
-  padding-right: 0px;
+    padding-left: 0px;
+    padding-right: 0px;
 }
 
 .lg-checkbox {
-  transform: scale(1.5);
-  margin-right: 5px;
+    transform: scale(1.5);
+    margin-right: 5px;
 }
 
 .scroll-margin {
-  scroll-margin: 58px;
+    scroll-margin: 58px;
+}
+
+.box-hover:hover {
+    border-color: lightblue;
 }

--- a/src/components/sections/LatticeView.tsx
+++ b/src/components/sections/LatticeView.tsx
@@ -5,7 +5,19 @@ import { CompilationResult, Slice } from "../../slices"
 import CellViewer from "../CellViewer"
 import { css } from "@emotion/react"
 import "./LatticeView.css"
-import { VStack, Box, Heading, Center, Switch, FormLabel, Flex } from "@chakra-ui/react"
+import {
+    VStack,
+    Box,
+    Heading,
+    Center,
+    Switch,
+    FormLabel,
+    Flex,
+    Text,
+    Stack,
+    HStack,
+} from "@chakra-ui/react"
+import parseCompilationText from "../../parseCompilationText"
 
 type SliceViewerProps = {
     slice: Slice
@@ -34,6 +46,9 @@ const LatticeView = ({ compilationResult }: LatticeViewProps): JSX.Element => {
     }
     const { compilation_text, slices } = compilationResult
     const slices_len = slices.length
+
+    const { input_circuit, circuit_after_pauli_rotations, circuit_after_litinski } =
+        parseCompilationText(compilation_text)
     // JS object that returns boolean when "previous" or "next" buttons need to be disabled
     const disable = {
         prev: selectedSliceNumber === 0,
@@ -51,7 +66,7 @@ const LatticeView = ({ compilationResult }: LatticeViewProps): JSX.Element => {
     const handleChange = () => {
         setCompilationText(!showCompilationText)
     }
-    // console.log(compilation_text)
+    console.log(compilation_text)
     return (
         <>
             <VStack spacing={4} align="stretch">
@@ -63,91 +78,112 @@ const LatticeView = ({ compilationResult }: LatticeViewProps): JSX.Element => {
                 </Center>
             </VStack>
 
-            <div id="lattice-view-output">
-                <Flex gap={5} justifyContent={"left"} py={6} flexWrap={"wrap"}>
-                    <FormLabel htmlFor="compilation-text" fontSize="xl" mb="0">
-                        View Compilation
-                    </FormLabel>
-                    <Switch
-                        id="compilation-text"
-                        size="lg"
-                        onChange={handleChange}
-                        defaultChecked={true}
-                    />
-                </Flex>
+            <Flex gap={3} justifyContent={"center"} py={4} flexWrap={"wrap"}>
+                <FormLabel htmlFor="compilation-text" fontSize="xl" mb="0">
+                    View Compilation
+                </FormLabel>
+                <Switch
+                    id="compilation-text"
+                    size="lg"
+                    onChange={handleChange}
+                    defaultChecked={true}
+                />
+            </Flex>
 
-                <div className="p-1 vertical-center">
-                    <div>
-                        {showCompilationText ? (
-                            <div
-                                id="compilation-text"
-                                className="mb-3"
-                                css={css`
-                                    margin-left: 10px;
-                                `}
-                            >
-                                <pre>{compilation_text}</pre>
-                            </div>
-                        ) : null}
-                    </div>
-                </div>
-
-                {/* Updated Toolbar */}
-                <div className="d-flex mt-1 scroll-margin">
-                    <div
-                        id="slice-toolbar"
-                        className="lattice-card shadow"
-                        css={css`
-                            flex-grow: 0;
-                            flex-shrink: 0;
-                            align-self: flex-start;
-                        `}
+            {showCompilationText ? (
+                <Flex gap={10} justifyContent={"center"} pt={0} pb={4} flexWrap={"wrap"}>
+                    <Box
+                        textAlign="center"
+                        borderWidth="4px"
+                        borderRadius="xl"
+                        boxShadow={"xl"}
+                        p={4}
                     >
-                        <div className="card-body center">
-                            <h5 className="card-title center">Select Time Slice </h5>
-                            <div className="card-text center">
-                                Slice {selectedSliceNumber + 1} / {slices_len}
+                        <Text className="line-1">Input Circuit</Text>
+                        <Box>
+                            <pre>{input_circuit}</pre>
+                        </Box>
+                    </Box>
+                    <Box
+                        textAlign="center"
+                        borderWidth="4px"
+                        borderRadius="xl"
+                        boxShadow={"xl"}
+                        p={5}
+                    >
+                        <Text className="line-1">Pauli Rotations</Text>
+                        <Box>
+                            <pre>{circuit_after_pauli_rotations}</pre>
+                        </Box>
+                    </Box>
+                    <Box
+                        textAlign="center"
+                        borderWidth="4px"
+                        borderRadius="xl"
+                        boxShadow={"xl"}
+                        p={5}
+                    >
+                        <Text className="line-1">Litinski Transform</Text>
+                        <pre>{circuit_after_litinski}</pre>
+                    </Box>
+                </Flex>
+            ) : null}
+
+            {/* Updated Toolbar */}
+            <div className="d-flex mt-1 scroll-margin">
+                <div
+                    id="slice-toolbar"
+                    className="lattice-card shadow"
+                    css={css`
+                        flex-grow: 0;
+                        flex-shrink: 0;
+                        align-self: flex-start;
+                    `}
+                >
+                    <div className="card-body center">
+                        <h5 className="card-title center">Select Time Slice </h5>
+                        <div className="card-text center">
+                            Slice {selectedSliceNumber + 1} / {slices_len}
+                        </div>
+                        {/* <hr css={css`width:100px; margin: auto`}/> */}
+                        <div
+                            className="btn-toolbar"
+                            role="toolbar"
+                            css={css`
+                                justify-content: center;
+                            `}
+                        >
+                            <div className="btn-group me-2" role="group">
+                                <button
+                                    disabled={disable["prev"]}
+                                    onClick={() => changeSlice(-1)}
+                                    className="btn btn-primary"
+                                >
+                                    Prev
+                                </button>
                             </div>
-                            {/* <hr css={css`width:100px; margin: auto`}/> */}
-                            <div
-                                className="btn-toolbar"
-                                role="toolbar"
-                                css={css`
-                                    justify-content: center;
-                                `}
-                            >
-                                <div className="btn-group me-2" role="group">
-                                    <button
-                                        disabled={disable["prev"]}
-                                        onClick={() => changeSlice(-1)}
-                                        className="btn btn-primary"
-                                    >
-                                        Prev
-                                    </button>
-                                </div>
-                                <div className="btn-group me-2" role="group">
-                                    <button
-                                        disabled={disable["next"]}
-                                        onClick={() => changeSlice(+1)}
-                                        className="btn btn-primary"
-                                    >
-                                        Next
-                                    </button>
-                                </div>
+                            <div className="btn-group me-2" role="group">
+                                <button
+                                    disabled={disable["next"]}
+                                    onClick={() => changeSlice(+1)}
+                                    className="btn btn-primary"
+                                >
+                                    Next
+                                </button>
                             </div>
                         </div>
                     </div>
                 </div>
+            </div>
 
-                <div id="draggable-container" className="mt-2">
-                    <SliceViewer slice={slices[selectedSliceNumber]} />
-                </div>
+            <div id="draggable-container" className="mt-2">
+                <SliceViewer slice={slices[selectedSliceNumber]} />
+            </div>
 
-                <div className="p-3">
-                    <a href="/" className="btn btn-info p-2">
-                        New Circuit
-                    </a>
-                </div>
+            <div className="p-3">
+                <a href="/" className="btn btn-info p-2">
+                    New Circuit
+                </a>
             </div>
         </>
     )

--- a/src/components/sections/LatticeView.tsx
+++ b/src/components/sections/LatticeView.tsx
@@ -163,7 +163,11 @@ const LatticeView = ({ compilationResult }: LatticeViewProps): JSX.Element => {
                             </Flex>
                         </Box>
                         <Box>
-                            <SliceIndexBar count={slices_len} selected={selectedSliceNumber} />
+                            <SliceIndexBar
+                                count={slices_len}
+                                selected={selectedSliceNumber}
+                                setSlice={setSelectedSliceNumber}
+                            />
                         </Box>
                     </Flex>
                 </Center>

--- a/src/components/sections/LatticeView.tsx
+++ b/src/components/sections/LatticeView.tsx
@@ -65,7 +65,6 @@ const LatticeView = ({ compilationResult }: LatticeViewProps): JSX.Element => {
     const handleChange = () => {
         setCompilationText(!showCompilationText)
     }
-    console.log(circuit_after_litinski)
     return (
         <>
             <VStack spacing={4} align="stretch">

--- a/src/components/sections/LatticeView.tsx
+++ b/src/components/sections/LatticeView.tsx
@@ -3,7 +3,6 @@ import React, { useRef } from "react"
 import { useState } from "react"
 import { CompilationResult, Slice } from "../../slices"
 import CellViewer from "../CellViewer"
-import { css } from "@emotion/react"
 import "./LatticeView.css"
 import {
     VStack,

--- a/src/components/sections/LatticeView.tsx
+++ b/src/components/sections/LatticeView.tsx
@@ -14,8 +14,7 @@ import {
     FormLabel,
     Flex,
     Text,
-    Stack,
-    HStack,
+
 } from "@chakra-ui/react"
 import parseCompilationText from "../../parseCompilationText"
 

--- a/src/components/sections/LatticeView.tsx
+++ b/src/components/sections/LatticeView.tsx
@@ -65,7 +65,7 @@ const LatticeView = ({ compilationResult }: LatticeViewProps): JSX.Element => {
     const handleChange = () => {
         setCompilationText(!showCompilationText)
     }
-    console.log(compilation_text)
+    console.log(circuit_after_litinski)
     return (
         <>
             <VStack spacing={4} align="stretch">
@@ -118,7 +118,7 @@ const LatticeView = ({ compilationResult }: LatticeViewProps): JSX.Element => {
                             <pre>{circuit_after_pauli_rotations}</pre>
                         </Box>
                     </Box>
-                    <Box
+                    {circuit_after_litinski=="" ? null:<Box
                         className="box-hover"
                         textAlign="center"
                         borderWidth="4px"
@@ -130,7 +130,7 @@ const LatticeView = ({ compilationResult }: LatticeViewProps): JSX.Element => {
                         <Box pt="5" pb="2">
                             <pre className="vcenter">{circuit_after_litinski}</pre>
                         </Box>
-                    </Box>
+                    </Box>}
                 </Flex>
             ) : null}
 
@@ -145,10 +145,18 @@ const LatticeView = ({ compilationResult }: LatticeViewProps): JSX.Element => {
                     <Flex flexWrap={"wrap"}>
                         <Box>
                             <Flex mr={3}>
-                                <Button fontSize='xl' disabled={disable["prev"]} onClick={() => changeSlice(-1)}>
+                                <Button
+                                    fontSize="xl"
+                                    disabled={disable["prev"]}
+                                    onClick={() => changeSlice(-1)}
+                                >
                                     Prev
                                 </Button>
-                                <Button fontSize='xl' disabled={disable["next"]} onClick={() => changeSlice(+1)}>
+                                <Button
+                                    fontSize="xl"
+                                    disabled={disable["next"]}
+                                    onClick={() => changeSlice(+1)}
+                                >
                                     Next
                                 </Button>
                             </Flex>

--- a/src/components/sections/LatticeView.tsx
+++ b/src/components/sections/LatticeView.tsx
@@ -5,7 +5,7 @@ import { CompilationResult, Slice } from "../../slices"
 import CellViewer from "../CellViewer"
 import { css } from "@emotion/react"
 import "./LatticeView.css"
-import { VStack, Box, StackDivider, Heading, Divider, Center} from "@chakra-ui/react"
+import { VStack, Box, Heading, Center, Switch, FormLabel, Flex } from "@chakra-ui/react"
 
 type SliceViewerProps = {
     slice: Slice
@@ -51,33 +51,30 @@ const LatticeView = ({ compilationResult }: LatticeViewProps): JSX.Element => {
     const handleChange = () => {
         setCompilationText(!showCompilationText)
     }
-
+    // console.log(compilation_text)
     return (
         <>
             <VStack spacing={4} align="stretch">
                 <Heading as="h1" size="2xl" mt={2} mb={2} textAlign={"center"}>
                     Lattice Viewer
                 </Heading>
-                <Center><Box h="20px" bg="blue.200" rounded="lg" width="75%"/>
+                <Center>
+                    <Box h="20px" bg="blue.200" rounded="lg" width="75%" />
                 </Center>
             </VStack>
 
             <div id="lattice-view-output">
-                <div className="form-check form-switch p-1">
-                    <div className="form-check form-switch">
-                        <input
-                            className="form-check-input lg-checkbox"
-                            type="checkbox"
-                            role="switch"
-                            id="flexSwitchCheckDefault"
-                            onChange={handleChange}
-                            defaultChecked={true}
-                        />
-                        <label className="form-check-label" htmlFor="flexSwitchCheckDefault">
-                            View Compilation
-                        </label>
-                    </div>
-                </div>
+                <Flex gap={5} justifyContent={"left"} py={6} flexWrap={"wrap"}>
+                    <FormLabel htmlFor="compilation-text" fontSize="xl" mb="0">
+                        View Compilation
+                    </FormLabel>
+                    <Switch
+                        id="compilation-text"
+                        size="lg"
+                        onChange={handleChange}
+                        defaultChecked={true}
+                    />
+                </Flex>
 
                 <div className="p-1 vertical-center">
                     <div>

--- a/src/components/sections/LatticeView.tsx
+++ b/src/components/sections/LatticeView.tsx
@@ -142,19 +142,21 @@ const LatticeView = ({ compilationResult }: LatticeViewProps): JSX.Element => {
                 </Center>
 
                 <Center pt={3}>
-                    <Box>
-                        <Flex mr={3}>
-                            <Button disabled={disable["prev"]} onClick={() => changeSlice(-1)}>
-                                Prev
-                            </Button>
-                            <Button disabled={disable["next"]} onClick={() => changeSlice(+1)}>
-                                Next
-                            </Button>
-                        </Flex>
-                    </Box>
-                    <Box>
-                        <SliceIndexBar count={slices_len} selected={selectedSliceNumber} />
-                    </Box>
+                    <Flex flexWrap={"wrap"}>
+                        <Box>
+                            <Flex mr={3}>
+                                <Button fontSize='xl' disabled={disable["prev"]} onClick={() => changeSlice(-1)}>
+                                    Prev
+                                </Button>
+                                <Button fontSize='xl' disabled={disable["next"]} onClick={() => changeSlice(+1)}>
+                                    Next
+                                </Button>
+                            </Flex>
+                        </Box>
+                        <Box>
+                            <SliceIndexBar count={slices_len} selected={selectedSliceNumber} />
+                        </Box>
+                    </Flex>
                 </Center>
             </Box>
 

--- a/src/components/sections/LatticeView.tsx
+++ b/src/components/sections/LatticeView.tsx
@@ -5,17 +5,7 @@ import { CompilationResult, Slice } from "../../slices"
 import CellViewer from "../CellViewer"
 import { css } from "@emotion/react"
 import "./LatticeView.css"
-import {
-    VStack,
-    Box,
-    Heading,
-    Center,
-    Switch,
-    FormLabel,
-    Flex,
-    Text,
-
-} from "@chakra-ui/react"
+import { VStack, Box, Heading, Center, Switch, FormLabel, Flex, Text } from "@chakra-ui/react"
 import parseCompilationText from "../../parseCompilationText"
 
 type SliceViewerProps = {
@@ -73,7 +63,7 @@ const LatticeView = ({ compilationResult }: LatticeViewProps): JSX.Element => {
                     Lattice Viewer
                 </Heading>
                 <Center>
-                    <Box h="20px" bg="blue.200" rounded="lg" width="75%" />
+                    <Box h="10px" bg="blue.200" rounded="lg" width="75%" />
                 </Center>
             </VStack>
 
@@ -92,6 +82,7 @@ const LatticeView = ({ compilationResult }: LatticeViewProps): JSX.Element => {
             {showCompilationText ? (
                 <Flex gap={10} justifyContent={"center"} pt={0} pb={4} flexWrap={"wrap"}>
                     <Box
+                        className="box-hover"
                         textAlign="center"
                         borderWidth="4px"
                         borderRadius="xl"
@@ -99,23 +90,26 @@ const LatticeView = ({ compilationResult }: LatticeViewProps): JSX.Element => {
                         p={4}
                     >
                         <Text className="line-1">Input Circuit</Text>
-                        <Box>
+                        <Box pt={1}>
                             <pre>{input_circuit}</pre>
                         </Box>
                     </Box>
                     <Box
+                        className="box-hover"
                         textAlign="center"
                         borderWidth="4px"
                         borderRadius="xl"
                         boxShadow={"xl"}
-                        p={5}
+                        p={4}
+                        minW="175px"
                     >
                         <Text className="line-1">Pauli Rotations</Text>
-                        <Box>
+                        <Box pt="5" pb="5">
                             <pre>{circuit_after_pauli_rotations}</pre>
                         </Box>
                     </Box>
                     <Box
+                        className="box-hover"
                         textAlign="center"
                         borderWidth="4px"
                         borderRadius="xl"
@@ -123,7 +117,9 @@ const LatticeView = ({ compilationResult }: LatticeViewProps): JSX.Element => {
                         p={5}
                     >
                         <Text className="line-1">Litinski Transform</Text>
-                        <pre>{circuit_after_litinski}</pre>
+                        <Box pt="5" pb="2">
+                            <pre className="vcenter">{circuit_after_litinski}</pre>
+                        </Box>
                     </Box>
                 </Flex>
             ) : null}

--- a/src/components/sections/LatticeView.tsx
+++ b/src/components/sections/LatticeView.tsx
@@ -5,8 +5,19 @@ import { CompilationResult, Slice } from "../../slices"
 import CellViewer from "../CellViewer"
 import { css } from "@emotion/react"
 import "./LatticeView.css"
-import { VStack, Box, Heading, Center, Switch, FormLabel, Flex, Text } from "@chakra-ui/react"
+import {
+    VStack,
+    Box,
+    Heading,
+    Center,
+    Switch,
+    FormLabel,
+    Flex,
+    Text,
+    Button,
+} from "@chakra-ui/react"
 import parseCompilationText from "../../parseCompilationText"
+import SliceIndexBar from "../SliceIndexBar"
 
 type SliceViewerProps = {
     slice: Slice
@@ -124,52 +135,29 @@ const LatticeView = ({ compilationResult }: LatticeViewProps): JSX.Element => {
                 </Flex>
             ) : null}
 
-            {/* Updated Toolbar */}
-            <div className="d-flex mt-1 scroll-margin">
-                <div
-                    id="slice-toolbar"
-                    className="lattice-card shadow"
-                    css={css`
-                        flex-grow: 0;
-                        flex-shrink: 0;
-                        align-self: flex-start;
-                    `}
-                >
-                    <div className="card-body center">
-                        <h5 className="card-title center">Select Time Slice </h5>
-                        <div className="card-text center">
-                            Slice {selectedSliceNumber + 1} / {slices_len}
-                        </div>
-                        {/* <hr css={css`width:100px; margin: auto`}/> */}
-                        <div
-                            className="btn-toolbar"
-                            role="toolbar"
-                            css={css`
-                                justify-content: center;
-                            `}
-                        >
-                            <div className="btn-group me-2" role="group">
-                                <button
-                                    disabled={disable["prev"]}
-                                    onClick={() => changeSlice(-1)}
-                                    className="btn btn-primary"
-                                >
-                                    Prev
-                                </button>
-                            </div>
-                            <div className="btn-group me-2" role="group">
-                                <button
-                                    disabled={disable["next"]}
-                                    onClick={() => changeSlice(+1)}
-                                    className="btn btn-primary"
-                                >
-                                    Next
-                                </button>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
+            <Box pt={3} pb={3}>
+                <Center>
+                    <Heading as="h3" size="xl">
+                        Select Time Slice
+                    </Heading>
+                </Center>
+
+                <Center pt={3}>
+                    <Box>
+                        <Flex mr={3}>
+                            <Button disabled={disable["prev"]} onClick={() => changeSlice(-1)}>
+                                Prev
+                            </Button>
+                            <Button disabled={disable["next"]} onClick={() => changeSlice(+1)}>
+                                Next
+                            </Button>
+                        </Flex>
+                    </Box>
+                    <Box>
+                        <SliceIndexBar count={slices_len} selected={selectedSliceNumber} />
+                    </Box>
+                </Center>
+            </Box>
 
             <div id="draggable-container" className="mt-2">
                 <SliceViewer slice={slices[selectedSliceNumber]} />

--- a/src/components/sections/LatticeView.tsx
+++ b/src/components/sections/LatticeView.tsx
@@ -128,7 +128,7 @@ const LatticeView = ({ compilationResult }: LatticeViewProps): JSX.Element => {
                         >
                             <Text className="line-1">Litinski Transform</Text>
                             <Box pt="5" pb="2">
-                                <pre className="vcenter">{circuit_after_litinski}</pre>
+                                <pre>{circuit_after_litinski}</pre>
                             </Box>
                         </Box>
                     )}

--- a/src/components/sections/LatticeView.tsx
+++ b/src/components/sections/LatticeView.tsx
@@ -5,6 +5,7 @@ import { CompilationResult, Slice } from "../../slices"
 import CellViewer from "../CellViewer"
 import { css } from "@emotion/react"
 import "./LatticeView.css"
+import { VStack, Box, StackDivider, Heading, Divider, Center} from "@chakra-ui/react"
 
 type SliceViewerProps = {
     slice: Slice
@@ -52,101 +53,106 @@ const LatticeView = ({ compilationResult }: LatticeViewProps): JSX.Element => {
     }
 
     return (
-        <div id="lattice-view-output">
-            <h2 ref={latticeSection} className="scroll-margin">
-                Lattice Viewer
-            </h2>
-            <hr />
+        <>
+            <VStack spacing={4} align="stretch">
+                <Heading as="h1" size="2xl" mt={2} mb={2} textAlign={"center"}>
+                    Lattice Viewer
+                </Heading>
+                <Center><Box h="20px" bg="blue.200" rounded="lg" width="75%"/>
+                </Center>
+            </VStack>
 
-            <div className="form-check form-switch p-1">
-                <div className="form-check form-switch">
-                    <input
-                        className="form-check-input lg-checkbox"
-                        type="checkbox"
-                        role="switch"
-                        id="flexSwitchCheckDefault"
-                        onChange={handleChange}
-                        defaultChecked={true}
-                    />
-                    <label className="form-check-label" htmlFor="flexSwitchCheckDefault">
-                        View Compilation
-                    </label>
+            <div id="lattice-view-output">
+                <div className="form-check form-switch p-1">
+                    <div className="form-check form-switch">
+                        <input
+                            className="form-check-input lg-checkbox"
+                            type="checkbox"
+                            role="switch"
+                            id="flexSwitchCheckDefault"
+                            onChange={handleChange}
+                            defaultChecked={true}
+                        />
+                        <label className="form-check-label" htmlFor="flexSwitchCheckDefault">
+                            View Compilation
+                        </label>
+                    </div>
                 </div>
-            </div>
 
-            <div className="p-1 vertical-center">
-                <div>
-                    {showCompilationText ? (
-                        <div
-                            id="compilation-text"
-                            className="mb-3"
-                            css={css`
-                                margin-left: 10px;
-                            `}
-                        >
-                            <pre>{compilation_text}</pre>
-                        </div>
-                    ) : null}
-                </div>
-            </div>
-
-            {/* Updated Toolbar */}
-            <div className="d-flex mt-1 scroll-margin">
-                <div
-                    id="slice-toolbar"
-                    className="lattice-card shadow"
-                    css={css`
-                        flex-grow: 0;
-                        flex-shrink: 0;
-                        align-self: flex-start;
-                    `}
-                >
-                    <div className="card-body center">
-                        <h5 className="card-title center">Select Time Slice </h5>
-                        <div className="card-text center">
-                            Slice {selectedSliceNumber + 1} / {slices_len}
-                        </div>
-                        {/* <hr css={css`width:100px; margin: auto`}/> */}
-                        <div
-                            className="btn-toolbar"
-                            role="toolbar"
-                            css={css`
-                                justify-content: center;
-                            `}
-                        >
-                            <div className="btn-group me-2" role="group">
-                                <button
-                                    disabled={disable["prev"]}
-                                    onClick={() => changeSlice(-1)}
-                                    className="btn btn-primary"
-                                >
-                                    Prev
-                                </button>
+                <div className="p-1 vertical-center">
+                    <div>
+                        {showCompilationText ? (
+                            <div
+                                id="compilation-text"
+                                className="mb-3"
+                                css={css`
+                                    margin-left: 10px;
+                                `}
+                            >
+                                <pre>{compilation_text}</pre>
                             </div>
-                            <div className="btn-group me-2" role="group">
-                                <button
-                                    disabled={disable["next"]}
-                                    onClick={() => changeSlice(+1)}
-                                    className="btn btn-primary"
-                                >
-                                    Next
-                                </button>
+                        ) : null}
+                    </div>
+                </div>
+
+                {/* Updated Toolbar */}
+                <div className="d-flex mt-1 scroll-margin">
+                    <div
+                        id="slice-toolbar"
+                        className="lattice-card shadow"
+                        css={css`
+                            flex-grow: 0;
+                            flex-shrink: 0;
+                            align-self: flex-start;
+                        `}
+                    >
+                        <div className="card-body center">
+                            <h5 className="card-title center">Select Time Slice </h5>
+                            <div className="card-text center">
+                                Slice {selectedSliceNumber + 1} / {slices_len}
+                            </div>
+                            {/* <hr css={css`width:100px; margin: auto`}/> */}
+                            <div
+                                className="btn-toolbar"
+                                role="toolbar"
+                                css={css`
+                                    justify-content: center;
+                                `}
+                            >
+                                <div className="btn-group me-2" role="group">
+                                    <button
+                                        disabled={disable["prev"]}
+                                        onClick={() => changeSlice(-1)}
+                                        className="btn btn-primary"
+                                    >
+                                        Prev
+                                    </button>
+                                </div>
+                                <div className="btn-group me-2" role="group">
+                                    <button
+                                        disabled={disable["next"]}
+                                        onClick={() => changeSlice(+1)}
+                                        className="btn btn-primary"
+                                    >
+                                        Next
+                                    </button>
+                                </div>
                             </div>
                         </div>
                     </div>
                 </div>
-            </div>
 
-            <div id="draggable-container" className="mt-2">
-                <SliceViewer slice={slices[selectedSliceNumber]} />
-            </div>
+                <div id="draggable-container" className="mt-2">
+                    <SliceViewer slice={slices[selectedSliceNumber]} />
+                </div>
 
-            <div className="p-3">
-                <a href="/" className="btn btn-info p-2">
-                    New Circuit
-                </a>
+                <div className="p-3">
+                    <a href="/" className="btn btn-info p-2">
+                        New Circuit
+                    </a>
+                </div>
             </div>
-        </div>
+        </>
     )
 }
 

--- a/src/components/sections/LatticeView.tsx
+++ b/src/components/sections/LatticeView.tsx
@@ -176,12 +176,6 @@ const LatticeView = ({ compilationResult }: LatticeViewProps): JSX.Element => {
             <div id="draggable-container" className="mt-2">
                 <SliceViewer slice={slices[selectedSliceNumber]} />
             </div>
-
-            <div className="p-3">
-                <a href="/" className="btn btn-info p-2">
-                    New Circuit
-                </a>
-            </div>
         </>
     )
 }

--- a/src/components/sections/LatticeView.tsx
+++ b/src/components/sections/LatticeView.tsx
@@ -118,19 +118,21 @@ const LatticeView = ({ compilationResult }: LatticeViewProps): JSX.Element => {
                             <pre>{circuit_after_pauli_rotations}</pre>
                         </Box>
                     </Box>
-                    {circuit_after_litinski=="" ? null:<Box
-                        className="box-hover"
-                        textAlign="center"
-                        borderWidth="4px"
-                        borderRadius="xl"
-                        boxShadow={"xl"}
-                        p={5}
-                    >
-                        <Text className="line-1">Litinski Transform</Text>
-                        <Box pt="5" pb="2">
-                            <pre className="vcenter">{circuit_after_litinski}</pre>
+                    {circuit_after_litinski == "" ? null : (
+                        <Box
+                            className="box-hover"
+                            textAlign="center"
+                            borderWidth="4px"
+                            borderRadius="xl"
+                            boxShadow={"xl"}
+                            p={5}
+                        >
+                            <Text className="line-1">Litinski Transform</Text>
+                            <Box pt="5" pb="2">
+                                <pre className="vcenter">{circuit_after_litinski}</pre>
+                            </Box>
                         </Box>
-                    </Box>}
+                    )}
                 </Flex>
             ) : null}
 

--- a/src/components/sections/LatticeView.tsx
+++ b/src/components/sections/LatticeView.tsx
@@ -173,9 +173,11 @@ const LatticeView = ({ compilationResult }: LatticeViewProps): JSX.Element => {
                 </Center>
             </Box>
 
-            <div id="draggable-container" className="mt-2">
-                <SliceViewer slice={slices[selectedSliceNumber]} />
-            </div>
+            <Box>
+                <div id="draggable-container" className="mt-2 mb-5">
+                    <SliceViewer slice={slices[selectedSliceNumber]} />
+                </div>
+            </Box>
         </>
     )
 }

--- a/src/parseCompilationText.ts
+++ b/src/parseCompilationText.ts
@@ -1,41 +1,17 @@
-const t = `Input Circuit:
-    ┌───┐     ┌─┐   
-    q_0: ┤ H ├──■──┤M├───
-    └───┘┌─┴─┐└╥┘┌─┐
-    q_1: ─────┤ X ├─╫─┤M├
-        └───┘ ║ └╥┘
-    c: 2/═══════════╩══╩═
-              0  1 
-    Circuit as Pauli rotations:
-    q0--|X|--|Z|--|X|--|Z|--|Z|--|I|--|Z|--|I|
-    q1--|I|--|I|--|I|--|X|--|I|--|X|--|I|--|Z|
-    pi*  1/4  1/4  1/4  1/4 -1/4 -1/4   M    M 
-
-    Circuit after the Litinski Transform:
-    q0--|X|--|X|
-    q1--|I|--|Z|
-    pi*  -M   -M
-`
-
-function parseCompilationText(compilation_text) {
+function parseCompilationText(compilation_text: string) {
     // Manually parse Compilation text into each part
     const compilation_text_split = compilation_text.split("Circuit")
-    var input_circuit = compilation_text_split[1].slice(2)
+    const input_circuit = compilation_text_split[1].slice(2)
 
-    console.log(input_circuit)
-
-    var pauli_rotations_split = compilation_text_split[2].split(":")
-    console.log(pauli_rotations_split[1].slice(1))
+    const pauli_rotations_split = compilation_text_split[2].split(":")
 
     const circuit_after_litinski_split = compilation_text_split[3].split(":")
-    console.log(circuit_after_litinski_split[1])
 
     return {
-        input_circuit: input_circuit,
-        circuit_after_pauli_rotations: pauli_rotations_split[1],
-        circuit_after_litinski: circuit_after_litinski_split[1].slice(1),
+        "input_circuit": input_circuit,
+        "circuit_after_pauli_rotations": pauli_rotations_split[1].slice(1,-1),
+        "circuit_after_litinski": circuit_after_litinski_split[1].slice(1),
     }
 }
 
-const p = parseCompilationText(t)
-console.log(p)
+export default parseCompilationText

--- a/src/parseCompilationText.ts
+++ b/src/parseCompilationText.ts
@@ -9,7 +9,6 @@ function parseCompilationText(compilation_text: string) {
         circuit_after_pauli_rotations: pauli_rotations_split[1].slice(1, -1),
         circuit_after_litinski: "",
     }
-    console.log("PIXZZA11111:", compilationTextJson)
     if (compilation_text.includes("Litinski")) {
         const circuit_after_litinski_split = compilation_text_split[3].split(":")
         const circuit_after_litinski = circuit_after_litinski_split[1].slice(1)

--- a/src/parseCompilationText.ts
+++ b/src/parseCompilationText.ts
@@ -4,12 +4,12 @@ function parseCompilationText(compilation_text: string) {
     const input_circuit = compilation_text_split[1].slice(2)
 
     const pauli_rotations_split = compilation_text_split[2].split(":")
-    var compilationTextJson = {
+    const compilationTextJson = {
         input_circuit: input_circuit,
         circuit_after_pauli_rotations: pauli_rotations_split[1].slice(1, -1),
-        circuit_after_litinski: ""
-    } 
-    console.log("PIXZZA11111:",compilationTextJson)
+        circuit_after_litinski: "",
+    }
+    console.log("PIXZZA11111:", compilationTextJson)
     if (compilation_text.includes("Litinski")) {
         const circuit_after_litinski_split = compilation_text_split[3].split(":")
         const circuit_after_litinski = circuit_after_litinski_split[1].slice(1)

--- a/src/parseCompilationText.ts
+++ b/src/parseCompilationText.ts
@@ -8,9 +8,9 @@ function parseCompilationText(compilation_text: string) {
     const circuit_after_litinski_split = compilation_text_split[3].split(":")
 
     return {
-        "input_circuit": input_circuit,
-        "circuit_after_pauli_rotations": pauli_rotations_split[1].slice(1, -1),
-        "circuit_after_litinski": circuit_after_litinski_split[1].slice(1),
+        input_circuit: input_circuit,
+        circuit_after_pauli_rotations: pauli_rotations_split[1].slice(1, -1),
+        circuit_after_litinski: circuit_after_litinski_split[1].slice(1),
     }
 }
 

--- a/src/parseCompilationText.ts
+++ b/src/parseCompilationText.ts
@@ -1,0 +1,41 @@
+const t = `Input Circuit:
+    ┌───┐     ┌─┐   
+    q_0: ┤ H ├──■──┤M├───
+    └───┘┌─┴─┐└╥┘┌─┐
+    q_1: ─────┤ X ├─╫─┤M├
+        └───┘ ║ └╥┘
+    c: 2/═══════════╩══╩═
+              0  1 
+    Circuit as Pauli rotations:
+    q0--|X|--|Z|--|X|--|Z|--|Z|--|I|--|Z|--|I|
+    q1--|I|--|I|--|I|--|X|--|I|--|X|--|I|--|Z|
+    pi*  1/4  1/4  1/4  1/4 -1/4 -1/4   M    M 
+
+    Circuit after the Litinski Transform:
+    q0--|X|--|X|
+    q1--|I|--|Z|
+    pi*  -M   -M
+`
+
+function parseCompilationText(compilation_text) {
+    // Manually parse Compilation text into each part
+    const compilation_text_split = compilation_text.split("Circuit")
+    var input_circuit = compilation_text_split[1].slice(2)
+
+    console.log(input_circuit)
+
+    var pauli_rotations_split = compilation_text_split[2].split(":")
+    console.log(pauli_rotations_split[1].slice(1))
+
+    const circuit_after_litinski_split = compilation_text_split[3].split(":")
+    console.log(circuit_after_litinski_split[1])
+
+    return {
+        input_circuit: input_circuit,
+        circuit_after_pauli_rotations: pauli_rotations_split[1],
+        circuit_after_litinski: circuit_after_litinski_split[1].slice(1),
+    }
+}
+
+const p = parseCompilationText(t)
+console.log(p)

--- a/src/parseCompilationText.ts
+++ b/src/parseCompilationText.ts
@@ -4,14 +4,18 @@ function parseCompilationText(compilation_text: string) {
     const input_circuit = compilation_text_split[1].slice(2)
 
     const pauli_rotations_split = compilation_text_split[2].split(":")
-
-    const circuit_after_litinski_split = compilation_text_split[3].split(":")
-
-    return {
+    var compilationTextJson = {
         input_circuit: input_circuit,
         circuit_after_pauli_rotations: pauli_rotations_split[1].slice(1, -1),
-        circuit_after_litinski: circuit_after_litinski_split[1].slice(1),
+        circuit_after_litinski: ""
+    } 
+    console.log("PIXZZA11111:",compilationTextJson)
+    if (compilation_text.includes("Litinski")) {
+        const circuit_after_litinski_split = compilation_text_split[3].split(":")
+        const circuit_after_litinski = circuit_after_litinski_split[1].slice(1)
+        compilationTextJson.circuit_after_litinski = circuit_after_litinski
     }
+    return compilationTextJson
 }
 
 export default parseCompilationText

--- a/src/parseCompilationText.ts
+++ b/src/parseCompilationText.ts
@@ -9,7 +9,7 @@ function parseCompilationText(compilation_text: string) {
 
     return {
         "input_circuit": input_circuit,
-        "circuit_after_pauli_rotations": pauli_rotations_split[1].slice(1,-1),
+        "circuit_after_pauli_rotations": pauli_rotations_split[1].slice(1, -1),
         "circuit_after_litinski": circuit_after_litinski_split[1].slice(1),
     }
 }


### PR DESCRIPTION
Switched compilation Text and time slice toolbar over to Chakra. 

Compilation Text View refactored into Circuit, circuit after pauli, circuit after litinski boxes
- encountered difficulty vertically centering divs within boxes. It is most apparent for Circuit after Pauli rotations.
- looks "OK" as is but could be better, particularly for mobile and larger circuits.

Create temporary string parsing function to parse Compilation Text (will become JSON object from the lambda)

Create time slice stepper bar component
- this visually shows which time slice you are on rather than displaying a number.

