### PR TITLE
Fix link buttons, adding `isExternal` to links in About Us page

### DIFF
--- a/src/pages/AboutUs.tsx
+++ b/src/pages/AboutUs.tsx
@@ -48,10 +48,13 @@ const AboutUs = (): JSX.Element => {
                         love-hate relationship with Javascript.
                     </Text>
                     <Flex flexWrap={"wrap"} gap={3} justifyContent={"center"}>
-                        <Link href={"https://github.com/alexnguyenn"}>
+                        <Link href={"https://github.com/alexnguyenn"} isExternal>
                             <Icon as={FaGithub} w={6} h={6} opacity={"75%"} />
                         </Link>
-                        <Link href={"https://www.linkedin.com/in/alex-nguyen-906320163/"}>
+                        <Link
+                            href={"https://www.linkedin.com/in/alex-nguyen-906320163/"}
+                            isExternal
+                        >
                             <Icon as={FaLinkedin} w={7} h={7} opacity={"75%"} />
                         </Link>
                     </Flex>
@@ -76,10 +79,10 @@ const AboutUs = (): JSX.Element => {
                         Computing at SFU and did too many internships.
                     </Text>
                     <Flex flexWrap={"wrap"} gap={3} justifyContent={"center"}>
-                        <Link href={"https://github.com/gwwatkin"}>
+                        <Link href={"https://github.com/gwwatkin"} isExternal>
                             <Icon as={FaGithub} w={6} h={6} opacity={"75%"} />
                         </Link>
-                        <Link href={"https://www.linkedin.com/in/gwwatkins/"}>
+                        <Link href={"https://www.linkedin.com/in/gwwatkins/"} isExternal>
                             <Icon as={FaLinkedin} w={7} h={7} opacity={"75%"} />
                         </Link>
                     </Flex>
@@ -104,10 +107,10 @@ const AboutUs = (): JSX.Element => {
                         technologies. When I&apos;m not programming, I&apos;m surfing.
                     </Text>
                     <Flex flexWrap={"wrap"} gap={3} justifyContent={"center"}>
-                        <Link href={"https://github.com/Keelando"}>
+                        <Link href={"https://github.com/Keelando"} isExternal>
                             <Icon as={FaGithub} w={6} h={6} opacity={"75%"} />
                         </Link>
-                        <Link href={"https://www.linkedin.com/in/keelanwatkins87/"}>
+                        <Link href={"https://www.linkedin.com/in/keelanwatkins87/"} isExternal>
                             <Icon as={FaLinkedin} w={7} h={7} opacity={"75%"} />
                         </Link>
                     </Flex>
@@ -132,10 +135,10 @@ const AboutUs = (): JSX.Element => {
                         Man and the Wasp
                     </Text>
                     <Flex flexWrap={"wrap"} gap={3} justifyContent={"center"}>
-                        <Link href={"https://github.com/isolatedinformation"}>
+                        <Link href={"https://github.com/isolatedinformation"} isExternal>
                             <Icon as={FaGithub} w={6} h={6} opacity={"75%"} />
                         </Link>
-                        <Link href={"https://www.linkedin.com/in/isolatedinformation/"}>
+                        <Link href={"https://www.linkedin.com/in/isolatedinformation/"} isExternal>
                             <Icon as={FaLinkedin} w={7} h={7} opacity={"75%"} />
                         </Link>
                     </Flex>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -36,30 +36,28 @@ const Home = (): JSX.Element => {
                     operations on a surface code lattice.
                 </Text>
                 <Flex gap={6} direction={"row"} wrap={"wrap"} justify={"center"}>
-                    <Button size={"lg"}>
-                        <Link
-                            as={RouterLink}
-                            to={"/online-compiler"}
-                            _hover={{ textDecoration: "none", color: "inherit" }}
-                        >
-                            Try out the compiler
-                        </Link>
-                    </Button>
-                    <Button
-                        variant={"outline"}
-                        size={"lg"}
-                        rightIcon={<FaGithub />}
-                        borderWidth={2}
-                        _hover={{ borderColor: "gray.500" }}
+                    <Link
+                        as={RouterLink}
+                        to={"/online-compiler"}
+                        _hover={{ textDecoration: "none", color: "inherit" }}
                     >
-                        <Link
-                            _hover={{ textDecoration: "none", color: "inherit" }}
-                            isExternal
-                            href="https://github.com/latticesurgery-com/"
+                        <Button size={"lg"}>Try out the compiler</Button>
+                    </Link>
+                    <Link
+                        _hover={{ textDecoration: "none", color: "inherit" }}
+                        href="https://github.com/latticesurgery-com/"
+                        isExternal
+                    >
+                        <Button
+                            variant={"outline"}
+                            size={"lg"}
+                            rightIcon={<FaGithub />}
+                            borderWidth={2}
+                            _hover={{ borderColor: "gray.500" }}
                         >
                             Visit us on GitHub
-                        </Link>
-                    </Button>
+                        </Button>
+                    </Link>
                 </Flex>
             </Stack>
             <Stack my={"50px"} spacing={4} textAlign={"center"}>

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -11,15 +11,9 @@ const NotFound = (): JSX.Element => {
                 <Text mb={6} mx={"auto"} maxW={"xl"} textAlign={"center"}>
                     The page you are looking for does not exist.
                 </Text>
-                <Button colorScheme={"orange"}>
-                    <Link
-                        as={Routerlink}
-                        to="/"
-                        _hover={{ textDecoration: "none", color: "inherit" }}
-                    >
-                        Go to Home
-                    </Link>
-                </Button>
+                <Link as={Routerlink} to="/" _hover={{ textDecoration: "none", color: "inherit" }}>
+                    <Button colorScheme={"orange"}>Go to Home</Button>
+                </Link>
             </Box>
         </>
     )

--- a/src/pages/Overview.tsx
+++ b/src/pages/Overview.tsx
@@ -30,13 +30,8 @@ const Overview = (): JSX.Element => {
                 <Text mb={8}>
                     A great deal of inspiration was taken from Daniel Litinski&apos;s Game of
                     Surface Codes{" "}
-                    <Link
-                        as="sup"
-                        color="teal.500"
-                        href="https://arxiv.org/abs/1911.05759"
-                        isExternal
-                    >
-                        [1]
+                    <Link color="teal.500" href="https://arxiv.org/abs/1911.05759" isExternal>
+                        <Text as="sup">[1]</Text>
                     </Link>
                     . We follow Litinski&apos;s formulation of lattice surgery patch computation and
                     the pre processing of quantum circuits as Pauli rotations. We have also an
@@ -59,21 +54,11 @@ const Overview = (): JSX.Element => {
                     for the output circuit to perform the same computation specified by the input
                     circuit. Recent work has focused on building compilers that translate a logical
                     quantum circuit to a much larger error corrected one, by adopting QECCs{" "}
-                    <Link
-                        color="teal.500"
-                        as="sup"
-                        href="https://arxiv.org/abs/1906.07994"
-                        isExternal
-                    >
-                        [2]
+                    <Link color="teal.500" href="https://arxiv.org/abs/1906.07994" isExternal>
+                        <Text as="sup">[2]</Text>
                     </Link>
-                    <Link
-                        color="teal.500"
-                        as="sup"
-                        href="https://arxiv.org/abs/1911.05759"
-                        isExternal
-                    >
-                        [3]
+                    <Link color="teal.500" href="https://arxiv.org/abs/1911.05759" isExternal>
+                        <Text as="sup">[3]</Text>
                     </Link>
                     .
                 </Text>
@@ -84,12 +69,11 @@ const Overview = (): JSX.Element => {
                     surgery, which stores logical qubits in portions of the surface code&apos;s
                     lattice patches and performs logical operations by merging and splitting patches{" "}
                     <Link
-                        as="sup"
                         color="teal.500"
                         href="https://iopscience.iop.org/article/10.1088/1367-2630/14/12/123011/meta"
                         isExternal
                     >
-                        [4]
+                        <Text as="sup">[4]</Text>
                     </Link>
                     .
                 </Text>

--- a/src/pages/Overview.tsx
+++ b/src/pages/Overview.tsx
@@ -38,11 +38,11 @@ const Overview = (): JSX.Element => {
                     >
                         [1]
                     </Link>
-                    . We follow Litinski’s formulation of lattice surgery patch computation and the
-                    pre processing of quantum circuits as Pauli rotations. We have also an option to
-                    remove the stabilizer part of the circuit from the quantum computation with an
-                    algorithm outlined in the same paper. This algorithm is available in this
-                    project as the &ldquo;Litinski Transform&rdquo;.
+                    . We follow Litinski&apos;s formulation of lattice surgery patch computation and
+                    the pre processing of quantum circuits as Pauli rotations. We have also an
+                    option to remove the stabilizer part of the circuit from the quantum computation
+                    with an algorithm outlined in the same paper. This algorithm is available in
+                    this project as the &ldquo;Litinski Transform&rdquo;.
                 </Text>
                 <Heading as="h2" size="lg" mb={8} textAlign={"center"}>
                     Surface Codes and Lattice Surgery


### PR DESCRIPTION
Seems like the correct to do link button is to have the link component as the parent, or else you would have to click on the text to navigate. 

Also added `isExternal` to the Github and Linkedin links in About Us page