### PR TITLE
Add HTTPS to Steve's photo + update Kero's description

### DIFF
--- a/src/pages/AboutUs.tsx
+++ b/src/pages/AboutUs.tsx
@@ -144,7 +144,7 @@ const AboutUs = (): JSX.Element => {
                     sub="Assistant Professor at Simon Fraser University, Canada Research Chair"
                     avatarSrc="https://www.sfu.ca/content/sfu/physics/people/faculty/hoikwanl.img.1629284380.png"
                     description={
-                        "I aim at solving practicality issues of quantum technology, likely be aided by the" +
+                        "I aim at solving practicality issues of quantum technology, likely to be aided by the" +
                         "freedom of Canada, friendliness of Canadians, and fragrance of Tim Hortons coffee."
                     }
                 >

--- a/src/pages/AboutUs.tsx
+++ b/src/pages/AboutUs.tsx
@@ -124,7 +124,7 @@ const AboutUs = (): JSX.Element => {
                 <Profile
                     name="Steven Pearce"
                     sub="Lecturer at Simon Fraser University"
-                    avatarSrc="http://www.cs.sfu.ca/~stevenp/scan0005.jpg"
+                    avatarSrc="https://www.cs.sfu.ca/~stevenp/scan0005.jpg"
                     description={
                         "Former astrophysicist, current non-conformist. Went from tsunami waves to wave-particles."
                     }

--- a/src/pages/AboutUs.tsx
+++ b/src/pages/AboutUs.tsx
@@ -144,7 +144,7 @@ const AboutUs = (): JSX.Element => {
                     sub="Assistant Professor at Simon Fraser University, Canada Research Chair"
                     avatarSrc="https://www.sfu.ca/content/sfu/physics/people/faculty/hoikwanl.img.1629284380.png"
                     description={
-                        "I aim at solving practicality issues of quantum technology, likely to be aided by the" +
+                        "I aim to solve practicality issues of quantum technology, likely to be aided by the" +
                         "freedom of Canada, friendliness of Canadians, and fragrance of Tim Hortons coffee."
                     }
                 >

--- a/src/pages/AboutUs.tsx
+++ b/src/pages/AboutUs.tsx
@@ -144,9 +144,8 @@ const AboutUs = (): JSX.Element => {
                     sub="Assistant Professor at Simon Fraser University, Canada Research Chair"
                     avatarSrc="https://www.sfu.ca/content/sfu/physics/people/faculty/hoikwanl.img.1629284380.png"
                     description={
-                        "My research aims to solve the current practicality issues of quantum technology. " +
-                        "I will likely be facilitated by the freedom of Canada, friendliness of Canadians, " +
-                        "and fragrance of Tim Hortons coffee."
+                        "I aim at solving practicality issues of quantum technology, likely be aided by the" +
+                        "freedom of Canada, friendliness of Canadians, and fragrance of Tim Hortons coffee."
                     }
                 >
                     <Link


### PR DESCRIPTION
Was causing the website to appear as not secure:
![Screenshot_20220124_233044](https://user-images.githubusercontent.com/36427091/150931038-b1ab9c1d-a2e7-40d0-895c-e3abdcfaaad5.png)

![image](https://user-images.githubusercontent.com/36427091/150931435-fa727be9-439c-4179-a3fe-3318ae82cb2e.png)
