### PR TITLE
Add support for the Resource Estimation compilation stage

### DIFF
--- a/src/components/sections/LatticeView.tsx
+++ b/src/components/sections/LatticeView.tsx
@@ -89,22 +89,24 @@ const LatticeView = ({ compilationResult }: LatticeViewProps): JSX.Element => {
 
             {showCompilationText && (
                 <Flex gap={10} justifyContent={"center"} pt={0} pb={4} flexWrap={"wrap"}>
-                    {stages.map( stage => <Box
+                    {stages.map((stage, idx) => (
+                        <Box
                             className="box-hover"
                             textAlign="center"
                             borderWidth="4px"
                             borderRadius="xl"
                             boxShadow={"xl"}
+                            key={idx}
                             p={4}
-                          >
-                              <Text className="line-1">{stage.name}</Text>
-                              <Box pt={1}>
-                              <pre>{stage.content}</pre>
-                              </Box>
-                          </Box>)
-                    }
+                        >
+                            <Text className="line-1">{stage.name}</Text>
+                            <Box pt={1}>
+                                <pre>{stage.content}</pre>
+                            </Box>
+                        </Box>
+                    ))}
                 </Flex>
-            ) }
+            )}
 
             <Box pt={3} pb={3}>
                 <Center>

--- a/src/components/sections/LatticeView.tsx
+++ b/src/components/sections/LatticeView.tsx
@@ -46,8 +46,7 @@ const LatticeView = ({ compilationResult }: LatticeViewProps): JSX.Element => {
     const { compilation_text, slices } = compilationResult
     const slices_len = slices.length
 
-    const { input_circuit, circuit_after_pauli_rotations, circuit_after_litinski } =
-        parseCompilationText(compilation_text)
+    const stages = parseCompilationText(compilation_text)
     // JS object that returns boolean when "previous" or "next" buttons need to be disabled
     const disable = {
         prev: selectedSliceNumber === 0,
@@ -88,52 +87,24 @@ const LatticeView = ({ compilationResult }: LatticeViewProps): JSX.Element => {
                 />
             </Flex>
 
-            {showCompilationText ? (
+            {showCompilationText && (
                 <Flex gap={10} justifyContent={"center"} pt={0} pb={4} flexWrap={"wrap"}>
-                    <Box
-                        className="box-hover"
-                        textAlign="center"
-                        borderWidth="4px"
-                        borderRadius="xl"
-                        boxShadow={"xl"}
-                        p={4}
-                    >
-                        <Text className="line-1">Input Circuit</Text>
-                        <Box pt={1}>
-                            <pre>{input_circuit}</pre>
-                        </Box>
-                    </Box>
-                    <Box
-                        className="box-hover"
-                        textAlign="center"
-                        borderWidth="4px"
-                        borderRadius="xl"
-                        boxShadow={"xl"}
-                        p={4}
-                        minW="175px"
-                    >
-                        <Text className="line-1">Pauli Rotations</Text>
-                        <Box pt="5" pb="5">
-                            <pre>{circuit_after_pauli_rotations}</pre>
-                        </Box>
-                    </Box>
-                    {circuit_after_litinski == "" ? null : (
-                        <Box
+                    {stages.map( stage => <Box
                             className="box-hover"
                             textAlign="center"
                             borderWidth="4px"
                             borderRadius="xl"
                             boxShadow={"xl"}
-                            p={5}
-                        >
-                            <Text className="line-1">Litinski Transform</Text>
-                            <Box pt="5" pb="2">
-                                <pre>{circuit_after_litinski}</pre>
-                            </Box>
-                        </Box>
-                    )}
+                            p={4}
+                          >
+                              <Text className="line-1">{stage.name}</Text>
+                              <Box pt={1}>
+                              <pre>{stage.content}</pre>
+                              </Box>
+                          </Box>)
+                    }
                 </Flex>
-            ) : null}
+            ) }
 
             <Box pt={3} pb={3}>
                 <Center>

--- a/src/parseCompilationText.ts
+++ b/src/parseCompilationText.ts
@@ -1,20 +1,34 @@
-function parseCompilationText(compilation_text: string) {
+class CompilationStage
+{
+    constructor(public name: string, public content: string) {}
+}
+
+const parseCompilationText = (compilation_text: string): Array<CompilationStage> => {
     // Manually parse Compilation text into each part
     const compilation_text_split = compilation_text.split("Circuit")
     const input_circuit = compilation_text_split[1].slice(2)
 
     const pauli_rotations_split = compilation_text_split[2].split(":")
-    const compilationTextJson = {
-        input_circuit: input_circuit,
-        circuit_after_pauli_rotations: pauli_rotations_split[1].slice(1, -1),
-        circuit_after_litinski: "",
-    }
+
+    const stages: Array<CompilationStage> = [
+        new CompilationStage("Input Circuit", input_circuit),
+        new CompilationStage("Pauli Rotations", pauli_rotations_split[1].slice(1, -1)),
+    ]
+
     if (compilation_text.includes("Litinski")) {
         const circuit_after_litinski_split = compilation_text_split[3].split(":")
         const circuit_after_litinski = circuit_after_litinski_split[1].slice(1)
-        compilationTextJson.circuit_after_litinski = circuit_after_litinski
+        stages.push(new CompilationStage("Litinski Transform", circuit_after_litinski))
     }
-    return compilationTextJson
+
+    if (compilation_text.includes("resource")) {
+        const circuit_after_resource_split = compilation_text_split[4].split(":\n")
+        const circuit_after_resource = circuit_after_resource_split[1]
+        stages.push(new CompilationStage("Resource Estimation", circuit_after_resource))
+    }
+
+    return stages
 }
 
 export default parseCompilationText
+

--- a/src/parseCompilationText.ts
+++ b/src/parseCompilationText.ts
@@ -1,5 +1,4 @@
-class CompilationStage
-{
+class CompilationStage {
     constructor(public name: string, public content: string) {}
 }
 
@@ -31,4 +30,3 @@ const parseCompilationText = (compilation_text: string): Array<CompilationStage>
 }
 
 export default parseCompilationText
-


### PR DESCRIPTION
Need it to work on https://github.com/latticesurgery-com/lattice-surgery-compiler/issues/227. Shouldn't affect other things.

Hopefully when https://github.com/latticesurgery-com/lattice-surgery-compiler/pull/220 goes in we can switch from this parsing to using JSON directly