### PR TITLE
Remove bootstrap

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,30 +1,32 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    
-    <!-- Favicon -->
-    <link rel="icon" type="image/jpg" href="%PUBLIC_URL%/favicon.jpg">
-    <link rel="apple-touch-icon" sizes="180x180" href="%PUBLIC_URL%/apple-touch-icon.png">
-    <link rel="icon" type="image/png" sizes="32x32" href="%PUBLIC_URL%/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="%PUBLIC_URL%/favicon-16x16.png">
-    
-    <!-- Metadata -->
-    <link rel="manifest" href="%PUBLIC_URL%/site.webmanifest">
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
 
-    <!-- Bootstrap 5 -->
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-BmbxuPwQa2lc/FVzBcNJ7UAyJxM6wuqIj61tLrc4wSX0szH/Ev+nYRRuWlolflfl" crossorigin="anonymous">
+        <!-- Favicon -->
+        <link rel="icon" type="image/jpg" href="%PUBLIC_URL%/favicon.jpg" />
+        <link rel="apple-touch-icon" sizes="180x180" href="%PUBLIC_URL%/apple-touch-icon.png" />
+        <link rel="icon" type="image/png" sizes="32x32" href="%PUBLIC_URL%/favicon-32x32.png" />
+        <link rel="icon" type="image/png" sizes="16x16" href="%PUBLIC_URL%/favicon-16x16.png" />
 
-    <!-- font awesome -->
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css" integrity="sha512-iBBXm8fW90+nuLcSKlbmrPcLa0OT92xO1BIsZ+ywDWZCvqsWgccV3gFoRBv0z+8dLJgyAHIhR35VZc2oM/gI1w==" crossorigin="anonymous" />
+        <!-- Metadata -->
+        <link rel="manifest" href="%PUBLIC_URL%/site.webmanifest" />
 
-    <title>Lattice Surgery Compiler</title>
-</head>
-<body>
-<noscript>You need to enable JavaScript to run this app.</noscript>
-<div id="root"></div>
-<!--
+        <!-- font awesome -->
+        <link
+            rel="stylesheet"
+            href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css"
+            integrity="sha512-iBBXm8fW90+nuLcSKlbmrPcLa0OT92xO1BIsZ+ywDWZCvqsWgccV3gFoRBv0z+8dLJgyAHIhR35VZc2oM/gI1w=="
+            crossorigin="anonymous"
+        />
+
+        <title>Lattice Surgery Compiler</title>
+    </head>
+    <body>
+        <noscript>You need to enable JavaScript to run this app.</noscript>
+        <div id="root"></div>
+        <!--
   This HTML file is a template.
   If you open it directly in the browser, you will see an empty page.
   You can add webfonts, meta tags, or analytics to this file.
@@ -32,5 +34,5 @@
   To begin the development, run `npm start` or `yarn start`.
   To create a production bundle, use `npm run build` or `yarn build`.
 -->
-</body>
+    </body>
 </html>

--- a/src/components/CellViewer.tsx
+++ b/src/components/CellViewer.tsx
@@ -1,4 +1,5 @@
 /** @jsxImportSource @emotion/react */
+import { Box } from "@chakra-ui/react"
 import { css } from "@emotion/react"
 import { PatchType, Orientation, EdgeType, ActivityType } from "../slices"
 import { VisualArrayCell } from "../slices"
@@ -54,8 +55,7 @@ type CellViewerProps = {
 
 const CellViewer = ({ cell, row_idx, col_idx }: CellViewerProps) => {
     return (
-        <div
-            className="lattice-cell-inside"
+        <Box
             css={css`
                 height: 100%;
                 width: 100%;
@@ -111,7 +111,7 @@ const CellViewer = ({ cell, row_idx, col_idx }: CellViewerProps) => {
                     </p>
                 )}
             </span>
-        </div>
+        </Box>
     )
 }
 

--- a/src/components/sections/LatticeView.css
+++ b/src/components/sections/LatticeView.css
@@ -31,12 +31,8 @@
 
 .lattice-cell {
     border: 0.5px solid #a2abae;
-    min-width: 50px;
-    max-width: 130px;
-    /* width: 12vw; */
     position: relative;
     font-size: 18px;
-    aspect-ratio: 1 / 1;
 }
 
 .qubit-state {

--- a/src/components/sections/LatticeView.css
+++ b/src/components/sections/LatticeView.css
@@ -1,11 +1,4 @@
 /* lattice view styles */
-
-.lattice-card {
-    border: 2px solid black;
-    border-radius: 15px;
-    width: 200px;
-    background-color: #ffdbb3 !important;
-}
 .center {
     text-align: center;
 }
@@ -26,7 +19,7 @@
     background-color: lavender;
     border-bottom: solid darkgrey 1.5vh;
 }
-#draggable-container {
+#lattice-container {
     font-size: 0;
     z-index: 10;
 }
@@ -40,9 +33,10 @@
     border: 0.5px solid #a2abae;
     min-width: 50px;
     max-width: 130px;
-    width: 12vw;
+    /* width: 12vw; */
     position: relative;
     font-size: 18px;
+    aspect-ratio: 1 / 1;
 }
 
 .qubit-state {

--- a/src/components/sections/LatticeView.tsx
+++ b/src/components/sections/LatticeView.tsx
@@ -42,7 +42,12 @@ const SliceViewer = ({ slice }: SliceViewerProps) => {
                     gap="0"
                 >
                     {row.map((cell, col_idx) => (
-                        <GridItem className="lattice-cell" key={col_idx}>
+                        <GridItem
+                            w={cell_dimension_pixels}
+                            h={cell_dimension_pixels}
+                            className="lattice-cell"
+                            key={col_idx}
+                        >
                             <CellViewer
                                 cell={cell}
                                 row_idx={row_idx}

--- a/src/components/sections/LatticeView.tsx
+++ b/src/components/sections/LatticeView.tsx
@@ -15,7 +15,6 @@ import {
     Text,
     Button,
     Grid,
-    AspectRatio,
     GridItem,
 } from "@chakra-ui/react"
 import parseCompilationText from "../../parseCompilationText"

--- a/src/components/sections/LatticeView.tsx
+++ b/src/components/sections/LatticeView.tsx
@@ -14,6 +14,9 @@ import {
     Flex,
     Text,
     Button,
+    Grid,
+    AspectRatio,
+    GridItem,
 } from "@chakra-ui/react"
 import parseCompilationText from "../../parseCompilationText"
 import SliceIndexBar from "../SliceIndexBar"
@@ -22,19 +25,38 @@ import { IoSaveOutline } from "react-icons/io5"
 type SliceViewerProps = {
     slice: Slice
 }
-const SliceViewer = ({ slice }: SliceViewerProps) => (
-    <div className="slice grid">
-        {slice.map((row, row_idx) => (
-            <div className="lattice-row row flex-nowrap" key={row_idx}>
-                {row.map((cell, col_idx) => (
-                    <div className="lattice-cell ratio ratio-1x1 col" key={col_idx}>
-                        <CellViewer cell={cell} row_idx={row_idx} col_idx={col_idx} key={col_idx} />
-                    </div>
-                ))}
-            </div>
-        ))}
-    </div>
-)
+const SliceViewer = ({ slice }: SliceViewerProps) => {
+    const cell_dimension_pixels = "130px"
+    const m_rows = slice.length
+    const n_cols = slice[0].length
+    return (
+        <Grid
+            templateRows={`repeat(${m_rows}, ${cell_dimension_pixels})`}
+            gap="0"
+            className="slice"
+        >
+            {slice.map((row, row_idx) => (
+                <Grid
+                    className="lattice-row"
+                    key={row_idx}
+                    templateColumns={`repeat(${n_cols}, ${cell_dimension_pixels})`}
+                    gap="0"
+                >
+                    {row.map((cell, col_idx) => (
+                        <GridItem className="lattice-cell" key={col_idx}>
+                            <CellViewer
+                                cell={cell}
+                                row_idx={row_idx}
+                                col_idx={col_idx}
+                                key={col_idx}
+                            />
+                        </GridItem>
+                    ))}
+                </Grid>
+            ))}
+        </Grid>
+    )
+}
 
 type LatticeViewProps = {
     compilationResult: CompilationResult
@@ -175,10 +197,8 @@ const LatticeView = ({ compilationResult }: LatticeViewProps): JSX.Element => {
                 </Center>
             </Box>
 
-            <Box>
-                <div id="draggable-container" className="mt-2 mb-5">
-                    <SliceViewer slice={slices[selectedSliceNumber]} />
-                </div>
+            <Box mt="4" pb="8" id="lattice-container">
+                <SliceViewer slice={slices[selectedSliceNumber]} />
             </Box>
         </>
     )


### PR DESCRIPTION
switched the lattice view to chakra ui

I'm not the biggest fan of Chakra's grid system, but like anything, it's just a matter of getting used to it.

we can probably use media queries as @alexnguyenn suggested to modify width/height of cells on the fly. And I think it would be nice to have a scrollable div like there was before, as well as simple zoom functionality. So the state of the CSS is in flux as there will be sweeping changes to everything coming in subsequent PR's

there is a lot of inline css in the CellViewer that will be subsequently removed as well