### PR TITLE
remove font awesome CDN

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -13,14 +13,6 @@
         <!-- Metadata -->
         <link rel="manifest" href="%PUBLIC_URL%/site.webmanifest" />
 
-        <!-- font awesome -->
-        <link
-            rel="stylesheet"
-            href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css"
-            integrity="sha512-iBBXm8fW90+nuLcSKlbmrPcLa0OT92xO1BIsZ+ywDWZCvqsWgccV3gFoRBv0z+8dLJgyAHIhR35VZc2oM/gI1w=="
-            crossorigin="anonymous"
-        />
-
         <title>Lattice Surgery Compiler</title>
     </head>
     <body>


### PR DESCRIPTION
I think font awesome was a hold-over from the Terminator font, and I think we aren't using it anymore.