### PR TITLE
Remove redundant error classes

### DIFF
--- a/src/components/sections/CircuitSelect/index.tsx
+++ b/src/components/sections/CircuitSelect/index.tsx
@@ -45,7 +45,7 @@ const CircuitSelect = ({ appState, setAppState }: AppStateProps) => {
                 compilationIsLoading: false,
             })
         } else {
-            submitCompileRequest({ appState, setAppState }, data as string, doTransform, repeats)
+            submitCompileRequest(setAppState, data as string, doTransform, repeats)
         }
     }
 
@@ -53,7 +53,7 @@ const CircuitSelect = ({ appState, setAppState }: AppStateProps) => {
         const file_url = `${process.env.PUBLIC_URL}/assets/demo_circuits/${example}`
         const data = await fetch(file_url).then((response) => response.text())
         if (data) {
-            submitCompileRequest({ appState, setAppState }, data as string, doTransform, repeats)
+            submitCompileRequest(setAppState, data as string, doTransform, repeats)
         }
     }
 

--- a/src/components/sections/CircuitSelect/index.tsx
+++ b/src/components/sections/CircuitSelect/index.tsx
@@ -18,7 +18,7 @@ import {
 import { IoChevronDownSharp } from "react-icons/io5"
 import { AppStateProps } from "../../../lib/appState"
 import FileUploader from "./FileUploader"
-import submitCompileRequest from "../../submitCompileRequest"
+import submitCompileRequest from "../../../lib/submitCompileRequest"
 import isDevMode from "../../../lib/isDevMode"
 import { CompilationResultSuccess } from "../../../lib/apiResponses"
 

--- a/src/components/submitCompileRequest.ts
+++ b/src/components/submitCompileRequest.ts
@@ -2,15 +2,9 @@ import { AppStateProps } from "../lib/appState"
 import queryString from "query-string"
 import { CompilationResult } from "../lib/slices"
 import axios from "axios"
-import {
-    JsonParseError,
-    ApiHttpError,
-    CompilationResultSuccess,
-    NoServerResponse,
-    CompilerError,
-} from "../lib/apiResponses"
+import { CompilationResultSuccess, ResponseError } from "../lib/apiResponses"
 
-const submitCompileRequest = (
+const submitCompileRequest = async (
     { appState, setAppState }: AppStateProps,
     circuitStr: string,
     doLitinskiTransform: boolean,
@@ -24,84 +18,82 @@ const submitCompileRequest = (
 
     // Modify State on Compile Request Submit
     setAppState({
-        ...appState,
         compilationIsLoading: true,
         apiResponse: null,
     })
 
-    // Async JS HTTP request to API endpoint, apiUrl
-    axios
-        .post(apiUrl, {
+    try {
+        const response = await axios.post(apiUrl, {
             circuit_source: "str",
             circuit: circuitStr,
             apply_litinski_transform: doLitinskiTransform,
         })
-        .then((response) => {
-            if (response.data.errorMessage) {
-                const errortype = response.data.errorType
-                const msg = response.data.errorMessage
-                setAppState({
-                    apiResponse: new CompilerError(errortype, msg),
-                    compilationIsLoading: false,
-                })
-            } else {
-                try {
-                    const responseJson = JSON.parse(response.data) as CompilationResult
-                    // Extend the slices by
-                    const REPEATS = repeats
-                    responseJson.slices.forEach((slice, slice_idx) => {
-                        slice.forEach((row, row_idx) => {
-                            for (let i = 0; i < REPEATS; i++) {
-                                responseJson.slices[slice_idx][row_idx] =
-                                    responseJson.slices[slice_idx][row_idx].concat(row)
-                            }
-                        })
-                        for (let i = 0; i < REPEATS; i++) {
-                            responseJson.slices[slice_idx] =
-                                responseJson.slices[slice_idx].concat(slice)
+
+        if (response.data.errorMessage) {
+            setAppState({
+                apiResponse: new ResponseError(
+                    "Compiler Error!",
+                    `${response.data.errorType}: ${response.data.errorMessage}`
+                ),
+                compilationIsLoading: false,
+            })
+        } else {
+            try {
+                const responseJson = JSON.parse(response.data) as CompilationResult
+
+                responseJson.slices.forEach((slice, slice_idx) => {
+                    slice.forEach((row, row_idx) => {
+                        for (let i = 0; i < repeats; i++) {
+                            responseJson.slices[slice_idx][row_idx] =
+                                responseJson.slices[slice_idx][row_idx].concat(row)
                         }
                     })
-                    setAppState({
-                        apiResponse: new CompilationResultSuccess(
-                            responseJson.slices,
-                            responseJson.compilation_text
-                        ),
-                        compilationIsLoading: false,
-                    })
-                } catch (error) {
-                    setAppState({
-                        apiResponse: new JsonParseError((error as Error).toString()),
-                        compilationIsLoading: false,
-                    })
-                }
-            }
+                    for (let i = 0; i < repeats; i++) {
+                        responseJson.slices[slice_idx] =
+                            responseJson.slices[slice_idx].concat(slice)
+                    }
+                })
 
-            // Catch Axios Errors: API errors -> timeout, error compiling, or no response
-        })
-        .catch((error) => {
-            // needs more testing. First two requests after a long lambda cooldown period result in CORS / Network Errors
-            if (error.response) {
-                console.error("AXIOS error:")
-                console.log(error.response.data)
-                console.log(error.response.headers)
-                console.log(error.response.status)
-                const error_code = error.response.status
-                const error_data = error.response.data
-                const error_headers = error.response.headers
-                // var api_error = new ApiHttpError(error_code,error_data,error_headers)
                 setAppState({
-                    // apiResponse: new ApiHttpError((error as Error).toString()),
-                    apiResponse: new ApiHttpError(error_code, error_data, error_headers),
+                    apiResponse: new CompilationResultSuccess(
+                        responseJson.slices,
+                        responseJson.compilation_text
+                    ),
+                    compilationIsLoading: false,
+                })
+            } catch (err) {
+                let msg
+                if (err instanceof Error) msg = err.message
+                else msg = String(err)
+                setAppState({
+                    apiResponse: new ResponseError("Failed to process results!", msg),
+                    compilationIsLoading: false,
+                })
+            }
+        }
+    } catch (err) {
+        if (err instanceof Error) {
+            if (axios.isAxiosError(err) && err.response) {
+                setAppState({
+                    apiResponse: new ResponseError(
+                        `API Error: ${err.response.status}`,
+                        err.response.data
+                    ),
                     compilationIsLoading: false,
                 })
             } else {
                 setAppState({
-                    // apiResponse: new ApiHttpError((error as Error).toString()),
-                    apiResponse: new NoServerResponse("Server did not respond"),
+                    apiResponse: new ResponseError("Error!", "Server did not response"),
                     compilationIsLoading: false,
                 })
             }
-        })
+        } else {
+            setAppState({
+                apiResponse: new ResponseError("Unknown Error!", String(err)),
+                compilationIsLoading: false,
+            })
+        }
+    }
 }
 
 export default submitCompileRequest

--- a/src/components/submitCompileRequest.ts
+++ b/src/components/submitCompileRequest.ts
@@ -1,11 +1,11 @@
-import { AppStateProps } from "../lib/appState"
+import { AppState } from "../lib/appState"
 import queryString from "query-string"
 import { CompilationResult } from "../lib/slices"
 import axios from "axios"
 import { CompilationResultSuccess, ResponseError } from "../lib/apiResponses"
 
 const submitCompileRequest = async (
-    { appState, setAppState }: AppStateProps,
+    setAppState: React.Dispatch<AppState>,
     circuitStr: string,
     doLitinskiTransform: boolean,
     repeats: number

--- a/src/lib/apiResponses.ts
+++ b/src/lib/apiResponses.ts
@@ -1,57 +1,24 @@
 import { Slices } from "./slices"
 
 // Different classes representing possible Api Response outcomes
-class JsonParseError {
+export class ResponseError {
+    title: string
     msg: string
-    constructor(msg: string) {
+
+    constructor(title: string, msg: string) {
+        this.title = title
         this.msg = msg
     }
 }
 
-class ApiHttpError {
-    code: number
-    msg: string
-    headers: string
-    constructor(code: number, msg: string, headers: string) {
-        this.code = code
-        this.msg = msg
-        this.headers = headers
-    }
-}
-
-class CompilerError {
-    msg: string
-    errortype: string
-    constructor(msg: string, errortype: string) {
-        this.msg = msg
-        this.errortype = errortype
-    }
-}
-
-class CompilationResultSuccess {
+export class CompilationResultSuccess {
     slices: Slices
     compilation_text: string
+
     constructor(slices: Slices, compilation_text: string) {
         this.slices = slices
         this.compilation_text = compilation_text
     }
 }
 
-class NoServerResponse {
-    response: string
-    constructor(response: string) {
-        this.response = response
-    }
-}
-
-type ApiResponse =
-    | null
-    | JsonParseError
-    | ApiHttpError
-    | CompilationResultSuccess
-    | CompilerError
-    | NoServerResponse
-
-export type { ApiResponse }
-
-export { JsonParseError, ApiHttpError, CompilationResultSuccess, NoServerResponse, CompilerError }
+export type ApiResponse = null | CompilationResultSuccess | ResponseError

--- a/src/lib/appState.ts
+++ b/src/lib/appState.ts
@@ -1,15 +1,12 @@
 import React from "react"
 import { ApiResponse } from "./apiResponses"
 
-class AppState {
+export class AppState {
     compilationIsLoading: boolean = false
     apiResponse: ApiResponse = null
 }
 
-interface AppStateProps {
+export interface AppStateProps {
     appState: AppState
     setAppState: React.Dispatch<AppState>
 }
-
-export { AppState }
-export type { AppStateProps }

--- a/src/lib/submitCompileRequest.ts
+++ b/src/lib/submitCompileRequest.ts
@@ -1,8 +1,10 @@
-import { AppState } from "../lib/appState"
+import { AppState } from "./appState"
 import queryString from "query-string"
-import { CompilationResult } from "../lib/slices"
+import { CompilationResult } from "./slices"
 import axios from "axios"
-import { CompilationResultSuccess, ResponseError } from "../lib/apiResponses"
+import { CompilationResultSuccess, ResponseError } from "./apiResponses"
+
+const API_URL = "https://api.latticesurgery.com/compile"
 
 const submitCompileRequest = async (
     setAppState: React.Dispatch<AppState>,
@@ -14,7 +16,7 @@ const submitCompileRequest = async (
 
     const apiUrl = queryStringMap.localapi
         ? `http://localhost:${queryStringMap.port || 9876}/compile`
-        : "https://api.latticesurgery.com/compile"
+        : API_URL
 
     // Modify State on Compile Request Submit
     setAppState({

--- a/src/pages/Compiler.tsx
+++ b/src/pages/Compiler.tsx
@@ -2,13 +2,7 @@ import { useState } from "react"
 import { AppState } from "../lib/appState"
 import isDevMode from "../lib/isDevMode"
 import LatticeView from "../components/sections/LatticeView"
-import {
-    JsonParseError,
-    ApiHttpError,
-    CompilationResultSuccess,
-    NoServerResponse,
-    CompilerError,
-} from "../lib/apiResponses"
+import { CompilationResultSuccess, ResponseError } from "../lib/apiResponses"
 import { Stack, Box, Alert, AlertIcon, AlertTitle, AlertDescription } from "@chakra-ui/react"
 import CircuitSelect from "../components/sections/CircuitSelect"
 
@@ -31,35 +25,11 @@ const CompilerPage = (): JSX.Element => {
                 <CircuitSelect appState={appState} setAppState={setAppState} />
             </Box>
             <Stack mt={10} spacing={5}>
-                {appState.apiResponse instanceof ApiHttpError && (
+                {appState.apiResponse instanceof ResponseError && (
                     <Alert w={{ base: "100%", sm: "80%", md: "65%" }} mx={"auto"} status="error">
                         <AlertIcon />
-                        <AlertTitle mr={2}>{"API Status: " + appState.apiResponse.code}</AlertTitle>
+                        <AlertTitle mr={2}>{appState.apiResponse.title}</AlertTitle>
                         <AlertDescription>{appState.apiResponse.msg}</AlertDescription>
-                    </Alert>
-                )}
-
-                {appState.apiResponse instanceof CompilerError && (
-                    <Alert w={{ base: "100%", sm: "80%", md: "65%" }} mx={"auto"} status="error">
-                        <AlertIcon />
-                        <AlertTitle mr={2}>Compiler Error!</AlertTitle>
-                        <AlertDescription>{`${appState.apiResponse.msg}: ${appState.apiResponse.errortype}`}</AlertDescription>
-                    </Alert>
-                )}
-
-                {appState.apiResponse instanceof JsonParseError && (
-                    <Alert w={{ base: "100%", sm: "80%", md: "65%" }} mx={"auto"} status="error">
-                        <AlertIcon />
-                        <AlertTitle mr={2}>Failed to process results!</AlertTitle>
-                        <AlertDescription>{appState.apiResponse.msg}</AlertDescription>
-                    </Alert>
-                )}
-
-                {appState.apiResponse instanceof NoServerResponse && (
-                    <Alert w={{ base: "100%", sm: "80%", md: "65%" }} mx={"auto"} status="error">
-                        <AlertIcon />
-                        <AlertTitle mr={2}>Server failed to respond!</AlertTitle>
-                        <AlertDescription>{appState.apiResponse.response}</AlertDescription>
                     </Alert>
                 )}
 


### PR DESCRIPTION
## Changelog 
* Unify all error classes for `ApiResponse` under 1 `ResponseError` class.
* Update the error handling accordingly.
* Move `submitCompileRequest.ts` to `src/lib/`.
* Minor stuffs. 

## Context
Closes #125 