### PR TITLE
React-Draggable lattice

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "query-string": "^7.0.1",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
+        "react-draggable": "^4.4.4",
         "react-dropzone": "^12.0.4",
         "react-icons": "^4.3.1",
         "react-router-dom": "^6.2.1",
@@ -6291,6 +6292,14 @@
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
+      "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/co": {
@@ -14535,6 +14544,19 @@
         "react": "17.0.2"
       }
     },
+    "node_modules/react-draggable": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.4.4.tgz",
+      "integrity": "sha512-6e0WdcNLwpBx/YIDpoyd2Xb04PB0elrDrulKUgdrIlwuYvxh5Ok9M+F8cljm8kPXXs43PmMzek9RrB1b7mLMqA==",
+      "dependencies": {
+        "clsx": "^1.1.1",
+        "prop-types": "^15.6.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0",
+        "react-dom": ">= 16.3.0"
+      }
+    },
     "node_modules/react-dropzone": {
       "version": "12.0.4",
       "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-12.0.4.tgz",
@@ -22163,6 +22185,11 @@
         "wrap-ansi": "^7.0.0"
       }
     },
+    "clsx": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
+      "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA=="
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -28020,6 +28047,15 @@
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "scheduler": "^0.20.2"
+      }
+    },
+    "react-draggable": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.4.4.tgz",
+      "integrity": "sha512-6e0WdcNLwpBx/YIDpoyd2Xb04PB0elrDrulKUgdrIlwuYvxh5Ok9M+F8cljm8kPXXs43PmMzek9RrB1b7mLMqA==",
+      "requires": {
+        "clsx": "^1.1.1",
+        "prop-types": "^15.6.0"
       }
     },
     "react-dropzone": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "query-string": "^7.0.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-draggable": "^4.4.4",
     "react-dropzone": "^12.0.4",
     "react-icons": "^4.3.1",
     "react-router-dom": "^6.2.1",

--- a/src/components/sections/LatticeView.css
+++ b/src/components/sections/LatticeView.css
@@ -18,7 +18,6 @@
 #lattice-container {
     width: fit-content;
     margin-top: 0;
-    margin-bottom: 30px;
 }
 
 .lattice-row {
@@ -59,4 +58,5 @@
     position: relative;
     left: 50%;
     margin-left: -48vw !important;
+    margin-top: 0 !important;
 }

--- a/src/components/sections/LatticeView.tsx
+++ b/src/components/sections/LatticeView.tsx
@@ -21,6 +21,7 @@ import parseCompilationText from "../../lib/parseCompilationText"
 import SliceIndexBar from "../SliceIndexBar"
 import { IoSaveOutline } from "react-icons/io5"
 import ZoomBar from "../Zoombar"
+import Draggable from "react-draggable"
 
 type SliceViewerProps = {
     slice: Slice
@@ -67,10 +68,12 @@ const SliceViewer = ({ slice, cellDimensionPixels }: SliceViewerProps) => {
     )
 }
 
-type LatticeViewProps = {
+interface LatticeViewProps {
     compilationResult: CompilationResult
+    repeats?: number
 }
-const LatticeView = ({ compilationResult }: LatticeViewProps): JSX.Element => {
+
+const LatticeView = ({ compilationResult, repeats = 1 }: LatticeViewProps): JSX.Element => {
     const [selectedSliceNumber, setSelectedSliceNumber] = React.useState<number>(0)
     const changeSlice = (delta: number) => {
         setSelectedSliceNumber(selectedSliceNumber + delta)
@@ -79,6 +82,8 @@ const LatticeView = ({ compilationResult }: LatticeViewProps): JSX.Element => {
     // cell font size is cellDimensionPixels divided by 20.
     const { compilation_text, slices } = compilationResult
     const slices_len = slices.length
+
+    const nodeRef = React.useRef(null) // Add to <Draggable> element
 
     const stages = parseCompilationText(compilation_text)
     // JS object that returns boolean when "previous" or "next" buttons need to be disabled
@@ -221,16 +226,26 @@ const LatticeView = ({ compilationResult }: LatticeViewProps): JSX.Element => {
                             setCellDimension={setCellDimensionPixels}
                         />
                     </Box>
-                    <Box id="lattice-container">
-                        <SliceViewer
-                            slice={slices[selectedSliceNumber]}
-                            cellDimensionPixels={cellDimensionPixels}
-                        />
+                    <Box
+                        w="100%"
+                        h={slices_len * cellDimensionPixels * (repeats + 1)}
+                        overflow="hidden"
+                    >
+                        <Draggable ref={nodeRef}>
+                            <Box id="lattice-container">
+                                <SliceViewer
+                                    slice={slices[selectedSliceNumber]}
+                                    cellDimensionPixels={cellDimensionPixels}
+                                />
+                            </Box>
+                        </Draggable>
                     </Box>
                 </Flex>
             </Box>
         </>
     )
 }
+
+// LatticeView.defaultProps = defaultProps
 
 export default LatticeView

--- a/src/lib/appState.ts
+++ b/src/lib/appState.ts
@@ -4,6 +4,7 @@ import { ApiResponse } from "./apiResponses"
 export class AppState {
     compilationIsLoading: boolean = false
     apiResponse: ApiResponse = null
+    repeats?: number = 1
 }
 
 export interface AppStateProps {

--- a/src/lib/submitCompileRequest.ts
+++ b/src/lib/submitCompileRequest.ts
@@ -62,6 +62,7 @@ const submitCompileRequest = async (
                         responseJson.compilation_text
                     ),
                     compilationIsLoading: false,
+                    repeats: repeats,
                 })
             } catch (err) {
                 let msg

--- a/src/pages/Compiler.tsx
+++ b/src/pages/Compiler.tsx
@@ -34,7 +34,10 @@ const CompilerPage = (): JSX.Element => {
                 )}
 
                 {appState.apiResponse instanceof CompilationResultSuccess && (
-                    <LatticeView compilationResult={appState.apiResponse} />
+                    <LatticeView
+                        compilationResult={appState.apiResponse}
+                        repeats={appState.repeats} // defaults to 1 if not set
+                    />
                 )}
             </Stack>
         </>


### PR DESCRIPTION
Make lattice draggable and confine to lattice view section with overflow hidden.

There is an error picked up by the browser console showing:
`findDOMNode is deprecated in StrictMode. findDOMNode was passed an instance of DraggableCore which is inside StrictMode.`

The fix for that only works if the bottom child is plain HTML, and it doesnt work if your components are custom, and I guess that includes ChakraUI <Box>.

From what I understand, <React.StrictMode> is used to catch problems in development and we won't see that error in production. 

The other fix is to remove <StrictMode> altogether, but it does catch problems from time to time so we should probably leave it. 