### PR TITLE
Hide circuit upload on compilation success

### DIFF
--- a/src/components/sections/LatticeView.tsx
+++ b/src/components/sections/LatticeView.tsx
@@ -103,10 +103,7 @@ const LatticeView = ({ compilationResult }: LatticeViewProps): JSX.Element => {
     }, [])
 
     // set state of checkbox switch
-    const [showCompilationText, setCompilationText] = useState(true)
-    const handleChange = () => {
-        setCompilationText(!showCompilationText)
-    }
+    const [showCompilationText, setCompilationText] = useState(false)
 
     // export slices to downloadable text JSON file
     const exportJson = (slices: Slices) => {
@@ -146,8 +143,10 @@ const LatticeView = ({ compilationResult }: LatticeViewProps): JSX.Element => {
                     <Switch
                         id="compilation-text"
                         size="lg"
-                        onChange={handleChange}
-                        defaultChecked={true}
+                        onChange={(e) => {
+                            setCompilationText(e.target.checked)
+                        }}
+                        checked={showCompilationText}
                     />
                 </Flex>
                 <Button borderWidth="2px" onClick={() => exportJson(slices)}>

--- a/src/pages/Compiler.tsx
+++ b/src/pages/Compiler.tsx
@@ -1,14 +1,31 @@
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import { AppState } from "../lib/appState"
 import isDevMode from "../lib/isDevMode"
 import LatticeView from "../components/sections/LatticeView"
 import { CompilationResultSuccess, ResponseError } from "../lib/apiResponses"
-import { Stack, Box, Alert, AlertIcon, AlertTitle, AlertDescription } from "@chakra-ui/react"
+import {
+    Stack,
+    Box,
+    Alert,
+    AlertIcon,
+    AlertTitle,
+    AlertDescription,
+    Button,
+    Center,
+} from "@chakra-ui/react"
 import CircuitSelect from "../components/sections/CircuitSelect"
 
 const CompilerPage = (): JSX.Element => {
     const [appState, setAppState] = useState(new AppState())
     const [repeats, setRepeats] = useState(0)
+    const [showCircuitSelect, setShowCircuitSelect] = useState(true)
+
+    useEffect(() => {
+        if (appState.apiResponse instanceof CompilationResultSuccess) {
+            setShowCircuitSelect(false)
+        }
+    }, [appState])
+
     return (
         <>
             {isDevMode() && (
@@ -22,12 +39,20 @@ const CompilerPage = (): JSX.Element => {
             )}
 
             <Box mt={10}>
-                <CircuitSelect
-                    appState={appState}
-                    setAppState={setAppState}
-                    repeats={repeats}
-                    setRepeats={setRepeats}
-                />
+                {showCircuitSelect ? (
+                    <CircuitSelect
+                        appState={appState}
+                        setAppState={setAppState}
+                        repeats={repeats}
+                        setRepeats={setRepeats}
+                    />
+                ) : (
+                    <Center>
+                        <Button size="lg" onClick={() => setShowCircuitSelect(true)}>
+                            New Circuit
+                        </Button>
+                    </Center>
+                )}
             </Box>
             <Stack mt={10} spacing={5}>
                 {appState.apiResponse instanceof ResponseError && (


### PR DESCRIPTION
## Changelogs
- On successful compilation, upload box is hidden & can be shown again via the New Circuit button. 
- Also hide View Compilation by default + minor logic fixes.

## Context
More screen estate for Lattice View = better  :+1:
## Demo
![Animation](https://user-images.githubusercontent.com/46719079/156896820-6cb8d7fb-16b6-4107-9996-ec8ea9a6abd2.gif)

