### PR TITLE
include compilation_text data in SAVE_JSON and upload feature

### DIFF
--- a/src/components/sections/CircuitSelect/index.tsx
+++ b/src/components/sections/CircuitSelect/index.tsx
@@ -46,7 +46,7 @@ const CircuitSelect = ({ appState, setAppState, repeats, setRepeats }: CircuitSe
         const data = await readFile(file)
         if (file.name.slice(-5) == ".json") {
             const json_data = JSON.parse(data as string)
-            if ((data as string).includes("compilation_text")) {
+            if (Object.prototype.hasOwnProperty.call(json_data, "compilation_text")) {
                 setAppState({
                     apiResponse: new CompilationResultSuccess(
                         json_data.slices,

--- a/src/components/sections/CircuitSelect/index.tsx
+++ b/src/components/sections/CircuitSelect/index.tsx
@@ -46,10 +46,19 @@ const CircuitSelect = ({ appState, setAppState, repeats, setRepeats }: CircuitSe
         const data = await readFile(file)
         if (file.name.slice(-5) == ".json") {
             const json_data = JSON.parse(data as string)
-            setAppState({
-                apiResponse: new CompilationResultSuccess(json_data, ""),
-                compilationIsLoading: false,
-            })
+            if ((data as string).includes("compilation_text")) {
+                const slices = json_data.slices
+                const compilation_text = json_data.compilation_text
+                setAppState({
+                    apiResponse: new CompilationResultSuccess(slices, compilation_text),
+                    compilationIsLoading: false,
+                })
+            } else {
+                setAppState({
+                    apiResponse: new CompilationResultSuccess(json_data, ""),
+                    compilationIsLoading: false,
+                })
+            }
         } else {
             submitCompileRequest(setAppState, data as string, doTransform, repeats)
         }

--- a/src/components/sections/CircuitSelect/index.tsx
+++ b/src/components/sections/CircuitSelect/index.tsx
@@ -47,10 +47,11 @@ const CircuitSelect = ({ appState, setAppState, repeats, setRepeats }: CircuitSe
         if (file.name.slice(-5) == ".json") {
             const json_data = JSON.parse(data as string)
             if ((data as string).includes("compilation_text")) {
-                const slices = json_data.slices
-                const compilation_text = json_data.compilation_text
                 setAppState({
-                    apiResponse: new CompilationResultSuccess(slices, compilation_text),
+                    apiResponse: new CompilationResultSuccess(
+                        json_data.slices,
+                        json_data.compilation_text
+                    ),
                     compilationIsLoading: false,
                 })
             } else {

--- a/src/components/sections/LatticeView.tsx
+++ b/src/components/sections/LatticeView.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource @emotion/react */
 import React, { useRef } from "react"
 import { useState } from "react"
-import { CompilationResult, Slice, Slices } from "../../lib/slices"
+import { CompilationResult, Slice } from "../../lib/slices"
 import CellViewer from "../CellViewer"
 import "./LatticeView.css"
 import {
@@ -106,8 +106,8 @@ const LatticeView = ({ compilationResult }: LatticeViewProps): JSX.Element => {
     const [showCompilationText, setCompilationText] = useState(false)
 
     // export slices to downloadable text JSON file
-    const exportJson = (slices: Slices) => {
-        const stringJson = JSON.stringify(slices)
+    const exportJson = (compilationResult: CompilationResult) => {
+        const stringJson = JSON.stringify(compilationResult)
         const blob = new Blob([stringJson], { type: "text/plain;charset=utf-8" })
         const url = window.URL || window.webkitURL
         const link = url.createObjectURL(blob)
@@ -149,7 +149,7 @@ const LatticeView = ({ compilationResult }: LatticeViewProps): JSX.Element => {
                         checked={showCompilationText}
                     />
                 </Flex>
-                <Button borderWidth="2px" onClick={() => exportJson(slices)}>
+                <Button borderWidth="2px" onClick={() => exportJson(compilationResult)}>
                     <Flex gap="4">
                         <Text fontSize="xl" margin="auto">
                             Save JSON


### PR DESCRIPTION
Right now, if a user Saves or uploads Json Slice data, no compilation_text data will be included or shown, since only the slices data is written to file, and parsed on a user upload.

This PR basically allows the user to save the compilationResult object as a string JSON file as is. 

If the user is generating slices in the command line without any compilation text, it will also work.

This is in anticipation of allowing compilation result sharing for #115